### PR TITLE
fix(ui): les menus actifs sont à nouveau visibles

### DIFF
--- a/packages/ui/src/styles/buttons.css
+++ b/packages/ui/src/styles/buttons.css
@@ -8,6 +8,25 @@
     box-shadow 0.25s, fill 0.25s;
 }
 
+.btn-menu,.btn-menu:visited {
+  cursor: pointer;
+  text-decoration: none;
+  border: none;
+  display: inline-block;
+  color: var(--color-text);
+  background-color: var(--color-transparent);
+}
+
+.btn-menu.active {
+  color: var(--color-neutral);
+  background-color: var(--color-transparent);
+}
+
+.btn-menu:hover, .btn-menu {
+  color: var(--color-inverse);
+  background-color: var(--color-transparent);
+}
+
 @button default {
   button-border-width: 0;
   button-color: var(--color-text) var(--color-bg) var(--color-bg);
@@ -73,12 +92,6 @@
   button-class: active disabled false;
 }
 
-.btn-menu {
-  button-color: var(--color-text) var(--color-neutral) var(--color-inverse);
-  button-background: var(--color-transparent) var(--color-transparent)
-    var(--color-transparent);
-  button-class: active disabled true;
-}
 
 .btn,
 .btn-alt,

--- a/packages/ui/src/styles/system/typography.css
+++ b/packages/ui/src/styles/system/typography.css
@@ -140,7 +140,7 @@ a {
     color: var(--color-text);
   }
 
-  &.active.exact-active {
+  &.active {
     color: var(--color-neutral);
   }
 }
@@ -158,7 +158,7 @@ a.color-bg {
     color: var(--color-bg);
   }
 
-  &.active.exact-active {
+  &.active {
     color: var(--color-neutral);
   }
 }


### PR DESCRIPTION
J'ai fais un tour rapide de l'application, j'ai pas vu d'autres régressions.

Après, je ne sais pas où se cachent tous les boutons.

Il faudrait continuer le mouvement d'enlever post-css sur les buttons parce qu'il y'a une confusion entre la classe .active et la pseudo-class :active dans le plugin. En gros, ça ne marche pas dans notre cas la pseudo-class :active et c'est pour ça qu'il y'avait tout ces "if" dans le code pour appliquer le style actif.