### PR TITLE
fix(build): le docker de l'api fonctionne

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -30,6 +30,7 @@ COPY --from=build-stage /app/packages/api/package.json ./packages/api/
 COPY --from=build-stage /app/packages/common/package.json ./packages/common/
 COPY --from=build-stage /app/packages/api/dist/ ./packages/api/dist/
 COPY --from=build-stage /app/node_modules ./node_modules/
+COPY --from=build-stage /app/packages/api/node_modules ./node_modules/
 # nous avons besoin des sources pour lancer certains scripts manuellement
 COPY --from=build-stage /app/packages/api/src ./packages/api/src/
 COPY --from=build-stage /app/packages/api/tsconfig.json ./packages/api/


### PR DESCRIPTION
Je n'ai pas cherché pourquoi (surement un conflit de dependances), mais dateformat se retrouve dans node_modules de l'api, et non à la racine.
