### PR TITLE
fix(statut): le statut du titre est à 'modification en instance' alors qu'il devrait être échu

### DIFF
--- a/packages/api/src/business/rules/titre-etape-publication-check.ts
+++ b/packages/api/src/business/rules/titre-etape-publication-check.ts
@@ -2,11 +2,12 @@ interface IDemarchePublicationIndex {
   [id: string]: string[]
 }
 
-const demarcheEtapesTypesPublication = {
+const demarcheEtapesTypesPublication: IDemarchePublicationIndex = {
   arm: ['def', 'sco', 'aco'],
   axm: ['dex', 'rpu'],
+  cxm: ['dex'],
   prm: ['rpu']
-} as IDemarchePublicationIndex
+}
 
 /**
  * Vérifie si l'étape est une étape de publication

--- a/packages/api/src/business/rules/titre-phases-find.test.ts
+++ b/packages/api/src/business/rules/titre-phases-find.test.ts
@@ -237,7 +237,7 @@ describe("phases d'une démarche", () => {
     const tested = titrePhasesFind(demarches, aujourdhui, titreTypeId)
     expect(tested).toStrictEqual([
       {
-        dateDebut: '1970-09-17',
+        dateDebut: '1970-09-09',
         dateFin: '2018-12-31',
         statutId: 'ech',
         titreDemarcheId: 'demarcheId1'
@@ -363,7 +363,7 @@ describe("phases d'une démarche", () => {
     const tested = titrePhasesFind(demarches, aujourdhui, titreTypeId)
     expect(tested).toStrictEqual([
       {
-        dateDebut: '1970-09-17',
+        dateDebut: '1970-09-09',
         dateFin: '2018-12-31',
         statutId: 'ech',
         titreDemarcheId: 'demarcheId1'


### PR DESCRIPTION
En attente du go de laure sur https://trello.com/c/rogyrAbm/254-fix-statut-le-statut-du-titre-est-%C3%A0-modification-en-instance-alors-quil-devrait-%C3%AAtre-%C3%A9chu