### PR TITLE
chore(api): on ne groupe plus les export en bas de fichier

### DIFF
--- a/packages/api/src/business/utils/__mocks__/titre-coordonnees-find.ts
+++ b/packages/api/src/business/utils/__mocks__/titre-coordonnees-find.ts
@@ -1,6 +1,6 @@
 import { ITitrePoint } from '../../../types'
 
-const titrePoints = [
+export const titrePoints = [
   {
     id: 'h-cx-courdemanges-1988-oct01-dpu01-1',
     groupe: 1,
@@ -23,5 +23,3 @@ const titrePoints = [
     coordonnees: { x: 1, y: 1 }
   }
 ] as ITitrePoint[]
-
-export { titrePoints }

--- a/packages/api/src/business/utils/__mocks__/titre-etape-demarche-etape-type-find-types.ts
+++ b/packages/api/src/business/utils/__mocks__/titre-etape-demarche-etape-type-find-types.ts
@@ -1,8 +1,6 @@
 import { IDemarcheType } from '../../../types'
 
-const demarcheType = {
+export const demarcheType = {
   etapesTypes: [{ id: 'xxx' }],
   nom: 'demarche'
 } as IDemarcheType
-
-export { demarcheType }

--- a/packages/api/src/business/utils/__mocks__/titre-valide-check-demarches.ts
+++ b/packages/api/src/business/utils/__mocks__/titre-valide-check-demarches.ts
@@ -1,6 +1,6 @@
 import { ITitreDemarche } from '../../../types'
 
-const titreDemarches = [
+export const titreDemarches = [
   { statutId: 'dep', type: {} },
   {
     phase: { dateDebut: '2014-11-02', dateFin: '2019-11-02' },
@@ -8,5 +8,3 @@ const titreDemarches = [
     type: {}
   }
 ] as ITitreDemarche[]
-
-export { titreDemarches }

--- a/packages/api/src/business/utils/titre-coordonnees-find.ts
+++ b/packages/api/src/business/utils/titre-coordonnees-find.ts
@@ -2,12 +2,10 @@ import { ITitrePoint } from '../../types'
 
 import { geojsonCenter } from '../../tools/geojson'
 
-const titreCoordonneesFind = (titrePoints?: ITitrePoint[] | null) => {
+export const titreCoordonneesFind = (titrePoints?: ITitrePoint[] | null) => {
   if (!titrePoints?.length) return null
 
   const [x, y] = geojsonCenter(titrePoints)
 
   return { x, y }
 }
-
-export { titreCoordonneesFind }

--- a/packages/api/src/business/utils/titre-demarches-etapes-rebuild.ts
+++ b/packages/api/src/business/utils/titre-demarches-etapes-rebuild.ts
@@ -19,7 +19,7 @@ const titreEtapesFilter = (titreEtapes: ITitreEtape[], date: string) =>
  * @returns démarches du titre
  */
 
-const titreDemarchesEtapesRebuild = (
+export const titreDemarchesEtapesRebuild = (
   date: string,
   titreDemarches: ITitreDemarche[],
   titreTypeId: string
@@ -56,5 +56,3 @@ const titreDemarchesEtapesRebuild = (
 
     return acc
   }, [])
-
-export { titreDemarchesEtapesRebuild }

--- a/packages/api/src/business/utils/titre-etape-demarche-etape-type-find.ts
+++ b/packages/api/src/business/utils/titre-etape-demarche-etape-type-find.ts
@@ -1,6 +1,6 @@
 import { IEtapeType } from '../../types'
 
-const titreEtapeDemarcheEtapeTypeFind = (
+export const titreEtapeDemarcheEtapeTypeFind = (
   etapeTypeId: string,
   etapesTypes: IEtapeType[],
   demarcheTypeNom: string
@@ -17,5 +17,3 @@ const titreEtapeDemarcheEtapeTypeFind = (
 
   return titreDemarcheEtapeType
 }
-
-export { titreEtapeDemarcheEtapeTypeFind }

--- a/packages/api/src/business/utils/titre-slug-and-relations-update.ts
+++ b/packages/api/src/business/utils/titre-slug-and-relations-update.ts
@@ -165,7 +165,7 @@ const relationsSlugsUpdate = async (
   return hasChanged
 }
 
-const titreSlugAndRelationsUpdate = async (
+export const titreSlugAndRelationsUpdate = async (
   titre: ITitre
 ): Promise<{ hasChanged: boolean; slug: string }> => {
   let slug = titreSlugFind(titre)
@@ -205,5 +205,3 @@ const titreSlugAndRelationsUpdate = async (
 
   return { hasChanged, slug }
 }
-
-export { titreSlugAndRelationsUpdate }

--- a/packages/api/src/business/utils/titre-valide-check.ts
+++ b/packages/api/src/business/utils/titre-valide-check.ts
@@ -11,7 +11,7 @@ import { titreDemarchesEtapesRebuild } from './titre-demarches-etapes-rebuild'
  * @param titreTypeId - id du type de titre
  * @param hasDemarcheDeposee - si un titre échu avec une démarche déposée doit être pris en compte
  */
-const titreValideCheck = (
+export const titreValideCheck = (
   titreDemarches: ITitreDemarche[],
   dateDebut: string,
   dateFin: string,
@@ -60,5 +60,3 @@ const titreValideCheck = (
 
   return false
 }
-
-export { titreValideCheck }

--- a/packages/api/src/business/validations/document-input-validate.ts
+++ b/packages/api/src/business/validations/document-input-validate.ts
@@ -2,7 +2,7 @@ import { IDocument } from '../../types'
 
 import { dateValidate } from '../../tools/date'
 
-const documentInputValidate = async (document: IDocument) => {
+export const documentInputValidate = async (document: IDocument) => {
   const errors = [] as string[]
 
   if (!document.id && !document.typeId) {
@@ -20,5 +20,3 @@ const documentInputValidate = async (document: IDocument) => {
 
   return errors
 }
-
-export { documentInputValidate }

--- a/packages/api/src/business/validations/document-updation-validate.ts
+++ b/packages/api/src/business/validations/document-updation-validate.ts
@@ -2,7 +2,7 @@ import { IDocument } from '../../types'
 
 import { dateValidate } from '../../tools/date'
 
-const documentUpdationValidate = async (document: IDocument) => {
+export const documentUpdationValidate = async (document: IDocument) => {
   const errors = [] as string[]
 
   const error = dateValidate(document.date)
@@ -13,5 +13,3 @@ const documentUpdationValidate = async (document: IDocument) => {
 
   return errors
 }
-
-export { documentUpdationValidate }

--- a/packages/api/src/business/validations/documents-types-validate.ts
+++ b/packages/api/src/business/validations/documents-types-validate.ts
@@ -1,6 +1,6 @@
 import { IDocument, IDocumentType } from '../../types'
 
-const documentsTypesValidate = (
+export const documentsTypesValidate = (
   documents?: IDocument[] | null,
   documentsTypes?: IDocumentType[]
 ) => {
@@ -27,5 +27,3 @@ const documentsTypesValidate = (
 
   return errors
 }
-
-export { documentsTypesValidate }

--- a/packages/api/src/business/validations/titre-activite-complete-check.ts
+++ b/packages/api/src/business/validations/titre-activite-complete-check.ts
@@ -2,7 +2,7 @@ import { IContenu, IDocument, IDocumentType, ISection } from '../../types'
 
 import { documentsTypesValidate } from './documents-types-validate'
 
-const titreActiviteCompleteCheck = (
+export const titreActiviteCompleteCheck = (
   sections: ISection[],
   contenu?: IContenu | null,
   documents?: IDocument[] | null,
@@ -29,5 +29,3 @@ const titreActiviteCompleteCheck = (
 
   return !documentsErrors.length
 }
-
-export { titreActiviteCompleteCheck }

--- a/packages/api/src/business/validations/titre-activite-deletion-validate.ts
+++ b/packages/api/src/business/validations/titre-activite-deletion-validate.ts
@@ -1,6 +1,8 @@
 import { ITitreActivite } from '../../types'
 
-const titreActiviteDeletionValidate = (titreActivite: ITitreActivite) => {
+export const titreActiviteDeletionValidate = (
+  titreActivite: ITitreActivite
+) => {
   const errors = [] as string[]
 
   if (!titreActivite.suppression) {
@@ -9,5 +11,3 @@ const titreActiviteDeletionValidate = (titreActivite: ITitreActivite) => {
 
   return errors
 }
-
-export { titreActiviteDeletionValidate }

--- a/packages/api/src/business/validations/titre-activite-input-validate.ts
+++ b/packages/api/src/business/validations/titre-activite-input-validate.ts
@@ -6,7 +6,7 @@ import { contenuDatesCheck } from './utils/contenu-dates-check'
 
 const datePropsNames = ['date'] as [keyof ITitreActivite]
 
-const titreActiviteInputValidate = (
+export const titreActiviteInputValidate = (
   titreActivite: ITitreActivite,
   activiteSections: ISection[]
 ) => {
@@ -41,5 +41,3 @@ const titreActiviteInputValidate = (
 
   return errors
 }
-
-export { titreActiviteInputValidate }

--- a/packages/api/src/business/validations/titre-demarche-updation-validate.ts
+++ b/packages/api/src/business/validations/titre-demarche-updation-validate.ts
@@ -1,6 +1,6 @@
 import { ITitreDemarche } from '../../types'
 
-const titreDemarcheUpdationValidate = async (
+export const titreDemarcheUpdationValidate = async (
   titreDemarcheNew: ITitreDemarche,
   titreDemarcheOld: ITitreDemarche
 ) => {
@@ -17,5 +17,3 @@ const titreDemarcheUpdationValidate = async (
 
   return errors
 }
-
-export { titreDemarcheUpdationValidate }

--- a/packages/api/src/business/validations/titre-etape-points-validate.ts
+++ b/packages/api/src/business/validations/titre-etape-points-validate.ts
@@ -1,6 +1,6 @@
 import { ITitrePoint } from '../../types'
 
-const titreEtapePointsValidate = (titrePoints: ITitrePoint[]) => {
+export const titreEtapePointsValidate = (titrePoints: ITitrePoint[]) => {
   const errors = titrePoints.reduce((errors: string[], point) => {
     if (
       !point.references.every(
@@ -25,5 +25,3 @@ const titreEtapePointsValidate = (titrePoints: ITitrePoint[]) => {
 
   return null
 }
-
-export { titreEtapePointsValidate }

--- a/packages/api/src/business/validations/titre-etape-type-and-status-validate.ts
+++ b/packages/api/src/business/validations/titre-etape-type-and-status-validate.ts
@@ -3,7 +3,7 @@ import { IEtapeType } from '../../types'
 // valide le type et le statut de l'étape en fonction des type d'étapes d'une démarche
 import { titreEtapeDemarcheEtapeTypeFind } from '../utils/titre-etape-demarche-etape-type-find'
 
-const titreEtapeTypeAndStatusValidate = (
+export const titreEtapeTypeAndStatusValidate = (
   etapeTypeId: string,
   etapeStatutId: string | undefined,
   etapesTypes: IEtapeType[],
@@ -35,5 +35,3 @@ const titreEtapeTypeAndStatusValidate = (
     return [e.message]
   }
 }
-
-export { titreEtapeTypeAndStatusValidate }

--- a/packages/api/src/business/validations/titre-updation-validate.ts
+++ b/packages/api/src/business/validations/titre-updation-validate.ts
@@ -1,7 +1,7 @@
 import { ITitre, IUtilisateur } from '../../types'
 import { isSuper } from 'camino-common/src/roles'
 
-const titreUpdationValidate = async (
+export const titreUpdationValidate = async (
   titreNew: ITitre,
   titreOld: ITitre,
   user: IUtilisateur | null | undefined
@@ -53,5 +53,3 @@ const titreUpdationValidate = async (
 
   return errors
 }
-
-export { titreUpdationValidate }

--- a/packages/api/src/business/validations/utilisateur-updation-validate.ts
+++ b/packages/api/src/business/validations/utilisateur-updation-validate.ts
@@ -17,7 +17,7 @@ import {
  * @returns une liste de messages d'erreur si l'utilisateur n'a pas le droit de faire les modifications
  */
 
-const utilisateurUpdationValidate = async (
+export const utilisateurUpdationValidate = async (
   user: IUtilisateur,
   utilisateur: IUtilisateur
 ) => {
@@ -57,5 +57,3 @@ const utilisateurUpdationValidate = async (
 
   return []
 }
-
-export { utilisateurUpdationValidate }

--- a/packages/api/src/business/validations/utils/contenu-dates-check.ts
+++ b/packages/api/src/business/validations/utils/contenu-dates-check.ts
@@ -2,7 +2,7 @@ import { ISection, IContenu } from '../../../types'
 
 import { dateValidate } from '../../../tools/date'
 
-const contenuDatesCheck = (sections: ISection[], contenu: IContenu) => {
+export const contenuDatesCheck = (sections: ISection[], contenu: IContenu) => {
   const errors = sections.reduce(
     (errors: string[], section) =>
       section.elements && contenu[section.id]
@@ -30,5 +30,3 @@ const contenuDatesCheck = (sections: ISection[], contenu: IContenu) => {
 
   return null
 }
-
-export { contenuDatesCheck }

--- a/packages/api/src/business/validations/utils/contenu-numbers-check.ts
+++ b/packages/api/src/business/validations/utils/contenu-numbers-check.ts
@@ -1,6 +1,9 @@
 import { IContenu, ISection } from '../../../types'
 
-const contenuNumbersCheck = (sections: ISection[], contenu: IContenu) => {
+export const contenuNumbersCheck = (
+  sections: ISection[],
+  contenu: IContenu
+) => {
   const errors = sections.reduce((errors: string[], section) => {
     if (!section.elements) return errors
 
@@ -26,5 +29,3 @@ const contenuNumbersCheck = (sections: ISection[], contenu: IContenu) => {
 
   return null
 }
-
-export { contenuNumbersCheck }

--- a/packages/api/src/business/validations/utils/heritage-contenu-validate.ts
+++ b/packages/api/src/business/validations/utils/heritage-contenu-validate.ts
@@ -1,6 +1,6 @@
 import { ISection, IHeritageContenu } from '../../../types'
 
-const heritageContenuValidate = (
+export const heritageContenuValidate = (
   sections?: ISection[] | null,
   heritageContenu?: IHeritageContenu | null
 ) => {
@@ -64,5 +64,3 @@ const heritageContenuValidate = (
 
   return errors
 }
-
-export { heritageContenuValidate }

--- a/packages/api/src/business/validations/utils/props-dates-check.ts
+++ b/packages/api/src/business/validations/utils/props-dates-check.ts
@@ -10,7 +10,7 @@ import { ITitreActivite, ITitreEtape } from '../../../types'
  *
  */
 
-const propsDatesCheck = <T extends ITitreActivite | ITitreEtape>(
+export const propsDatesCheck = <T extends ITitreActivite | ITitreEtape>(
   propsNames: [keyof T],
   element: T
 ) => {
@@ -31,5 +31,3 @@ const propsDatesCheck = <T extends ITitreActivite | ITitreEtape>(
 
   return null
 }
-
-export { propsDatesCheck }

--- a/packages/api/src/business/validations/utils/props-numbers-check.ts
+++ b/packages/api/src/business/validations/utils/props-numbers-check.ts
@@ -1,4 +1,4 @@
-const propsNumbersCheck = <T>(props: [keyof T], element: T) => {
+export const propsNumbersCheck = <T>(props: [keyof T], element: T) => {
   const errors = props.reduce((errors: string[], prop) => {
     if (element[prop] && (element[prop] as unknown as number) < 0) {
       errors.push(`le champ "${prop}" ne peut pas avoir une valeur négative`)
@@ -13,5 +13,3 @@ const propsNumbersCheck = <T>(props: [keyof T], element: T) => {
 
   return null
 }
-
-export { propsNumbersCheck }

--- a/packages/api/src/config/proj4.ts
+++ b/packages/api/src/config/proj4.ts
@@ -1,7 +1,7 @@
 import proj4 from 'proj4'
 import { sortedGeoSystemes } from 'camino-common/src/geoSystemes'
 
-const geoSystemesInit = () => {
+export const geoSystemesInit = () => {
   // initialise les définitions proj4
   // utilisées dans /tools/geo-convert
   proj4.defs(
@@ -11,5 +11,3 @@ const geoSystemesInit = () => {
     ])
   )
 }
-
-export { geoSystemesInit }

--- a/packages/api/src/database/models/_format/id-create.ts
+++ b/packages/api/src/database/models/_format/id-create.ts
@@ -1,6 +1,4 @@
 import cryptoRandomString from 'crypto-random-string'
 
-const idGenerate = () =>
+export const idGenerate = () =>
   cryptoRandomString({ length: 24, type: 'alphanumeric' })
-
-export { idGenerate }

--- a/packages/api/src/database/models/_format/titre-contenu.ts
+++ b/packages/api/src/database/models/_format/titre-contenu.ts
@@ -12,7 +12,7 @@ import {
  * @returns l'objet contenu formaté
  */
 
-const titreContenuFormat = (
+export const titreContenuFormat = (
   contenusTitreEtapesIds: IContenusTitreEtapesIds,
   titreDemarches?: ITitreDemarche[] | null
 ) => {
@@ -52,5 +52,3 @@ const titreContenuFormat = (
 
   return contenu
 }
-
-export { titreContenuFormat }

--- a/packages/api/src/database/models/_format/titre-insert.ts
+++ b/packages/api/src/database/models/_format/titre-insert.ts
@@ -1,6 +1,6 @@
 import { Pojo } from 'objection'
 
-const titreInsertFormat = (json: Pojo) => {
+export const titreInsertFormat = (json: Pojo) => {
   delete json.geojsonMultiPolygon
   delete json.geojsonPoints
   delete json.communes
@@ -21,5 +21,3 @@ const titreInsertFormat = (json: Pojo) => {
 
   return json
 }
-
-export { titreInsertFormat }

--- a/packages/api/src/database/queries/_titres-filters.ts
+++ b/packages/api/src/database/queries/_titres-filters.ts
@@ -21,7 +21,7 @@ const fieldFormat = (name: string, field: string) =>
 // - 'titres' depuis la table 'titres'
 // - 'titre' depuis la table 'titresDemarches'
 // root: nom de la table de base
-const titresFiltersQueryModify = (
+export const titresFiltersQueryModify = (
   {
     ids,
     perimetre,
@@ -288,5 +288,3 @@ const titresFiltersQueryModify = (
       .groupBy(`${root}.id`)
   }
 }
-
-export { titresFiltersQueryModify }

--- a/packages/api/src/database/queries/_utils.ts
+++ b/packages/api/src/database/queries/_utils.ts
@@ -2,7 +2,7 @@
 // supprime les parenthèses
 // retourne un tableau
 
-const stringSplit = (string: string) =>
+export const stringSplit = (string: string) =>
   //             [                ]  |  matche les caractères qui sont...
   //              a-z                |  ...ou bien une lettre minuscule
   //                 A-Z             |  ...ou bien une lettre majuscule
@@ -50,5 +50,3 @@ const stringSplit = (string: string) =>
         .replace(/(.*)-$/, '$1')
     )
     .filter(e => e) as string[]
-
-export { stringSplit }

--- a/packages/api/src/database/queries/globales.ts
+++ b/packages/api/src/database/queries/globales.ts
@@ -1,5 +1,3 @@
 import Globales from '../models/globales'
 
-const globaleGet = async (id: string) => Globales.query().findById(id)
-
-export { globaleGet }
+export const globaleGet = async (id: string) => Globales.query().findById(id)

--- a/packages/api/src/database/queries/graph/fields-format.ts
+++ b/packages/api/src/database/queries/graph/fields-format.ts
@@ -28,7 +28,7 @@ const graphTitreAdministrationsFormat = (fields: IFields, type: string) => {
 }
 
 // ajoute des propriétés requises par /database/queries/_format
-const fieldsFormat = (fields: IFields, parent: string) => {
+export const fieldsFormat = (fields: IFields, parent: string) => {
   const isParentTitre = [
     'titres',
     'titre',
@@ -211,5 +211,3 @@ const fieldsFormat = (fields: IFields, parent: string) => {
 
   return fields
 }
-
-export { fieldsFormat }

--- a/packages/api/src/database/queries/permissions/titres-demarches.ts
+++ b/packages/api/src/database/queries/permissions/titres-demarches.ts
@@ -23,7 +23,7 @@ import {
   isBureauDEtudes
 } from 'camino-common/src/roles'
 
-const titresDemarchesQueryModify = (
+export const titresDemarchesQueryModify = (
   q: QueryBuilder<TitresDemarches, TitresDemarches | TitresDemarches[]>,
   user: IUtilisateur | null | undefined
 ) => {
@@ -170,5 +170,3 @@ const titreEtapesCreationQuery = (
     return raw('false')
   }
 }
-
-export { titresDemarchesQueryModify }

--- a/packages/api/src/database/queries/permissions/titres-etapes.ts
+++ b/packages/api/src/database/queries/permissions/titres-etapes.ts
@@ -110,7 +110,7 @@ const specifiquesAdd = (
  * @params user - utilisateur connecté
  * @returns une requête d'étape(s)
  */
-const titresEtapesQueryModify = (
+export const titresEtapesQueryModify = (
   q: QueryBuilder<TitresEtapes, TitresEtapes | TitresEtapes[]>,
   user: IUtilisateur | null | undefined
 ) => {
@@ -204,5 +204,3 @@ const titresEtapesQueryModify = (
 
   return q
 }
-
-export { titresEtapesQueryModify }

--- a/packages/api/src/server/auth-basic.ts
+++ b/packages/api/src/server/auth-basic.ts
@@ -27,7 +27,7 @@ const userCredentialsCheck = async (email: string, motDePasse: string) => {
   return valid ? user : null
 }
 
-const authBasic = async (
+export const authBasic = async (
   req: express.Request,
   res: express.Response,
   next: express.NextFunction
@@ -63,5 +63,3 @@ const authBasic = async (
 
   next()
 }
-
-export { authBasic }

--- a/packages/api/src/server/graphql.ts
+++ b/packages/api/src/server/graphql.ts
@@ -10,7 +10,7 @@ interface IAuthRequestHttp extends http.IncomingMessage {
   }
 }
 
-const graphql = graphqlHTTP((req: IAuthRequestHttp, res) => ({
+export const graphql = graphqlHTTP((req: IAuthRequestHttp, res) => ({
   context: { user: req.user, res },
   customFormatErrorFn: err => ({
     locations: err.locations,
@@ -23,5 +23,3 @@ const graphql = graphqlHTTP((req: IAuthRequestHttp, res) => ({
   rootValue,
   schema
 }))
-
-export { graphql }

--- a/packages/api/src/server/rest.ts
+++ b/packages/api/src/server/rest.ts
@@ -49,7 +49,7 @@ type IRestResolver = (
   userId?: string
 ) => Promise<IRestResolverResult | null>
 
-const rest = express.Router()
+export const rest = express.Router()
 
 type ExpressRoute = (
   req: express.Request,
@@ -160,5 +160,3 @@ rest.use(
     next()
   }
 )
-
-export { rest }

--- a/packages/api/src/tools/annees-build.ts
+++ b/packages/api/src/tools/annees-build.ts
@@ -4,7 +4,7 @@
  * @param dateFin - date de fin au format 'yyy-mm-dd'
  */
 
-const anneesBuild = (dateDebut: string, dateFin: string) => {
+export const anneesBuild = (dateDebut: string, dateFin: string) => {
   const anneeDebut = new Date(dateDebut).getFullYear()
   const anneeFin = new Date(dateFin).getFullYear()
 
@@ -16,5 +16,3 @@ const anneesBuild = (dateDebut: string, dateFin: string) => {
 
   return annees
 }
-
-export { anneesBuild }

--- a/packages/api/src/tools/api-administrations/index.ts
+++ b/packages/api/src/tools/api-administrations/index.ts
@@ -134,7 +134,7 @@ const organismeDepartementGet = async (
   return organisme ? organismeFormat(organisme, departementId) : null
 }
 
-const organismesDepartementsGet = async (
+export const organismesDepartementsGet = async (
   departementsIdsNoms: { departementId: DepartementId; nom: string }[]
 ): Promise<Administration[]> => {
   const administrationsOrganismesRequests = departementsIdsNoms.map(
@@ -151,5 +151,3 @@ const organismesDepartementsGet = async (
 
   return organismesDepartements.filter((o): o is Administration => !!o)
 }
-
-export { organismesDepartementsGet }

--- a/packages/api/src/tools/api-cerbere/index.ts
+++ b/packages/api/src/tools/api-cerbere/index.ts
@@ -44,7 +44,7 @@ const cerbereProfileFormat = (attributes: { [key: string]: string }) =>
     {}
   )
 
-const login = async (ticket: string) => {
+export const login = async (ticket: string) => {
   try {
     const { attributes } = await cerbereClient.validate(ticket)
 
@@ -68,6 +68,5 @@ const login = async (ticket: string) => {
   }
 }
 
-const logout = (returnUrl: string) => cerbereClient.logout(returnUrl, true)
-
-export { login, logout }
+export const logout = (returnUrl: string) =>
+  cerbereClient.logout(returnUrl, true)

--- a/packages/api/src/tools/api-geo/index.ts
+++ b/packages/api/src/tools/api-geo/index.ts
@@ -59,7 +59,7 @@ const areaFormat = (area: IGeoJsonProperties): IArea => ({
   surface: area.surface as number
 })
 
-const apiGeoGet = async (
+export const apiGeoGet = async (
   geojson: IGeoJson,
   areasTypes: IAreaType[]
 ): Promise<IApiGeoResult | null> => {
@@ -95,5 +95,3 @@ const apiGeoGet = async (
 
   return areas
 }
-
-export { apiGeoGet }

--- a/packages/api/src/tools/api-insee/fetch.ts
+++ b/packages/api/src/tools/api-insee/fetch.ts
@@ -35,7 +35,7 @@ const tokenTest = async () => {
   }
 }
 
-const tokenInitialize = async () => {
+export const tokenInitialize = async () => {
   if (apiToken) return apiToken
 
   try {
@@ -279,7 +279,7 @@ const batchesBuild = (ids: string[]) => {
   )
 }
 
-const entreprisesEtablissementsFetch = async (ids: string[]) => {
+export const entreprisesEtablissementsFetch = async (ids: string[]) => {
   const batches = batchesBuild(ids)
 
   const queryFormat = (idsBatch: string[]) =>
@@ -313,7 +313,7 @@ const entreprisesEtablissementsFetch = async (ids: string[]) => {
   }, [])
 }
 
-const entreprisesFetch = async (ids: string[]) => {
+export const entreprisesFetch = async (ids: string[]) => {
   const batches = batchesBuild(ids)
 
   const queryFormat = (idsBatch: string[]) => {
@@ -348,5 +348,3 @@ const entreprisesFetch = async (ids: string[]) => {
     return r
   }, [])
 }
-
-export { entreprisesFetch, entreprisesEtablissementsFetch, tokenInitialize }

--- a/packages/api/src/tools/api-insee/format.ts
+++ b/packages/api/src/tools/api-insee/format.ts
@@ -109,7 +109,9 @@ const entrepriseEtablissementFormat = (
   return etablissement
 }
 
-const entrepriseEtablissementsFormat = (uniteLegale: IApiSirenUniteLegale) => {
+export const entrepriseEtablissementsFormat = (
+  uniteLegale: IApiSirenUniteLegale
+) => {
   // periodesUniteLegale est un tableau
   // classé par ordre de fin chronologique décroissant
   if (
@@ -127,7 +129,7 @@ const entrepriseEtablissementsFormat = (uniteLegale: IApiSirenUniteLegale) => {
   return entrepriseEtablissements
 }
 
-const entrepriseFormat = ({
+export const entrepriseFormat = ({
   uniteLegale,
   adresseEtablissement: adresse,
   siren
@@ -228,5 +230,3 @@ const entrepriseFormat = ({
 
   return entreprise
 }
-
-export { entrepriseEtablissementsFormat, entrepriseFormat }

--- a/packages/api/src/tools/api-insee/index.ts
+++ b/packages/api/src/tools/api-insee/index.ts
@@ -9,7 +9,9 @@ import { IEntreprise, IEntrepriseEtablissement } from '../../types'
 
 // cherche les établissements des entreprises
 // retourne des objets du modèle EntrepriseEtablissements
-const apiInseeEntreprisesEtablissementsGet = async (sirenIds: string[]) => {
+export const apiInseeEntreprisesEtablissementsGet = async (
+  sirenIds: string[]
+) => {
   if (!sirenIds.length) return []
 
   const token = await tokenInitialize()
@@ -35,7 +37,7 @@ const apiInseeEntreprisesEtablissementsGet = async (sirenIds: string[]) => {
 
 // cherche les adresses des entreprises
 // retourne des objets du modèle Entreprise
-const apiInseeEntreprisesGet = async (sirenIds: string[]) => {
+export const apiInseeEntreprisesGet = async (sirenIds: string[]) => {
   const token = await tokenInitialize()
 
   if (!token) {
@@ -59,7 +61,9 @@ const apiInseeEntreprisesGet = async (sirenIds: string[]) => {
   }, [])
 }
 
-const apiInseeEntrepriseAndEtablissementsGet = async (sirenId: string) => {
+export const apiInseeEntrepriseAndEtablissementsGet = async (
+  sirenId: string
+) => {
   const token = await tokenInitialize()
 
   if (!token) {
@@ -79,10 +83,4 @@ const apiInseeEntrepriseAndEtablissementsGet = async (sirenId: string) => {
   ])
 
   return entreprise
-}
-
-export {
-  apiInseeEntrepriseAndEtablissementsGet,
-  apiInseeEntreprisesGet,
-  apiInseeEntreprisesEtablissementsGet
 }

--- a/packages/api/src/tools/api-insee/types.ts
+++ b/packages/api/src/tools/api-insee/types.ts
@@ -1,24 +1,23 @@
-/* eslint-disable no-undef */
-interface IApiSirenUniteLegalePeriode
+export interface IApiSirenUniteLegalePeriode
   extends IApiSirenUnionUniteLegalePeriodeEtablissmentUnite {
   dateDebut: Date
   dateFin: Date
 }
 
-interface IApiSirenUnionUniteLegalePeriodeEtablissmentUnite {
+export interface IApiSirenUnionUniteLegalePeriodeEtablissmentUnite {
   nicSiegeUniteLegale: string | null
   denominationUniteLegale: string | null
   denominationUsuelle1UniteLegale: string | null
   nomUniteLegale: string | null
 }
 
-interface IApiSirenUnionUniteLegaleEtablissmentUnite {
+export interface IApiSirenUnionUniteLegaleEtablissmentUnite {
   prenomUsuelUniteLegale: string
   sexeUniteLegale: 'F' | 'M' | null
   sigleUniteLegale: string | null
 }
 
-interface IApiSirenEtablissementUnite
+export interface IApiSirenEtablissementUnite
   extends IApiSirenUnionUniteLegalePeriodeEtablissmentUnite,
     IApiSirenUnionUniteLegaleEtablissmentUnite {
   categorieEntreprise: string
@@ -26,7 +25,7 @@ interface IApiSirenEtablissementUnite
   dateCreationUniteLegale: Date | null
 }
 
-interface IApiSirenEtablissementAdresse {
+export interface IApiSirenEtablissementAdresse {
   codeCedexEtablissement: string | null
   codePaysEtrangerEtablissement: string | null
   numeroVoieEtablissement: string | null
@@ -38,19 +37,19 @@ interface IApiSirenEtablissementAdresse {
   libelleCommuneEtrangerEtablissement: string
 }
 
-interface IApiSirenEtablissement {
+export interface IApiSirenEtablissement {
   adresseEtablissement: IApiSirenEtablissementAdresse
   siren: string
   uniteLegale: IApiSirenEtablissementUnite
 }
 
-interface IApiSirenUniteLegale
+export interface IApiSirenUniteLegale
   extends IApiSirenUnionUniteLegaleEtablissmentUnite {
   siren: string
   periodesUniteLegale: IApiSirenUniteLegalePeriode[]
 }
 
-interface IApiSirenQuery {
+export interface IApiSirenQuery {
   fault?: {
     code: number
     description: string
@@ -69,26 +68,14 @@ interface IApiSirenQuery {
   }
 }
 
-interface IApiSirenQueryTypes extends IApiSirenQuery {
+export interface IApiSirenQueryTypes extends IApiSirenQuery {
   etablissements?: IApiSirenEtablissement[]
   unitesLegales?: IApiSirenUniteLegale[]
 }
 
-interface IApiSirenQueryToken extends IApiSirenQuery {
+export interface IApiSirenQueryToken extends IApiSirenQuery {
   result?: {
     // eslint-disable-next-line camelcase
     access_token: string
   }
-}
-
-export {
-  IApiSirenEtablissement,
-  IApiSirenUniteLegalePeriode,
-  IApiSirenEtablissementUnite,
-  IApiSirenUniteLegale,
-  IApiSirenQuery,
-  IApiSirenUnionUniteLegalePeriodeEtablissmentUnite,
-  IApiSirenUnionUniteLegaleEtablissmentUnite,
-  IApiSirenQueryTypes,
-  IApiSirenQueryToken
 }

--- a/packages/api/src/tools/api-mailjet/index.ts
+++ b/packages/api/src/tools/api-mailjet/index.ts
@@ -1,8 +1,6 @@
 import mj from 'node-mailjet'
 
-const mailjet = mj.connect(
+export const mailjet = mj.connect(
   process.env.API_MAILJET_KEY || 'fakeKey',
   process.env.API_MAILJET_SECRET!
 )
-
-export { mailjet }

--- a/packages/api/src/tools/api-mailjet/newsletter.ts
+++ b/packages/api/src/tools/api-mailjet/newsletter.ts
@@ -110,7 +110,7 @@ const contactAdd = async (Email: string) => {
 const recipientFind = (contactId: number, recipients: IRecipient[]) =>
   recipients.find(r => r.ListID === contactListId && r.ContactID === contactId)
 
-const newsletterSubscribersFind = async () => {
+export const newsletterSubscribersFind = async () => {
   try {
     const emails = [] as string[]
 
@@ -131,7 +131,7 @@ const newsletterSubscribersFind = async () => {
   }
 }
 
-const newsletterSubscriberCheck = async (email: string) => {
+export const newsletterSubscriberCheck = async (email: string) => {
   try {
     // est ce que le contact est inscrit à la liste
     return await contactListCheck(email)
@@ -141,7 +141,7 @@ const newsletterSubscriberCheck = async (email: string) => {
   }
 }
 
-const newsletterSubscriberUpdate = async (
+export const newsletterSubscriberUpdate = async (
   email: string,
   subscribed: boolean
 ) => {
@@ -182,10 +182,4 @@ const newsletterSubscriberUpdate = async (
   } catch (e: any) {
     throw new Error(e)
   }
-}
-
-export {
-  newsletterSubscribersFind,
-  newsletterSubscriberUpdate,
-  newsletterSubscriberCheck
 }

--- a/packages/api/src/tools/api-matomo/index.ts
+++ b/packages/api/src/tools/api-matomo/index.ts
@@ -214,7 +214,7 @@ const titresModifiesCountGet = async (duree: number) => {
   )
 }
 
-const matomoCacheInit = async () => {
+export const matomoCacheInit = async () => {
   console.info()
   console.info('- - -')
   console.info('rafraichissement du cache Matomo…')
@@ -256,7 +256,7 @@ const matomoCacheInit = async () => {
   return matomoCacheValue
 }
 
-const matomoData = async () => {
+export const matomoData = async () => {
   const matomoCache = await cacheGet('matomo')
 
   if (!matomoCache) {
@@ -290,5 +290,3 @@ const getPath = (
 
   return `${process.env.API_MATOMO_URL}/index.php?expanded=1${_params}&filter_limit=-1&format=JSON&idSite=${process.env.API_MATOMO_ID}&method=${method}&module=API&period=${period}&token_auth=${process.env.API_MATOMO_TOKEN}`
 }
-
-export { matomoData, matomoCacheInit }

--- a/packages/api/src/tools/database-to-json/index.ts
+++ b/packages/api/src/tools/database-to-json/index.ts
@@ -8,7 +8,7 @@ import { tables } from './tables'
 
 const dir = 'sources'
 
-const databaseToJsonExport = async () => {
+export const databaseToJsonExport = async () => {
   await rm(`./${dir}`, { recursive: true, force: true }, err => {
     if (err) {
       throw err
@@ -64,5 +64,3 @@ const fieldFormat = (field: IFields, key: string) => {
 
   return field[key]
 }
-
-export { databaseToJsonExport }

--- a/packages/api/src/tools/database-to-json/tables.ts
+++ b/packages/api/src/tools/database-to-json/tables.ts
@@ -1,5 +1,5 @@
 // Liste des noms des tables à sauvegarder au format json
-const tables = [
+export const tables = [
   { name: 'activites_statuts', orderBy: ['id'] },
   { name: 'activites_types', orderBy: ['id'] },
   {
@@ -135,5 +135,3 @@ const tables = [
     orderBy: ['utilisateur_id', 'entreprise_id']
   }
 ]
-
-export { tables }

--- a/packages/api/src/tools/demarches/etape-statut-check.ts
+++ b/packages/api/src/tools/demarches/etape-statut-check.ts
@@ -2,7 +2,7 @@ import { titresEtapesGet } from '../../database/queries/titres-etapes'
 import { titresTypesDemarchesTypesEtapesTypesGet } from '../../database/queries/metas'
 import { userSuper } from '../../database/user-super'
 
-const etapeStatutCheck = async () => {
+export const etapeStatutCheck = async () => {
   console.info()
   console.info('- - -')
   console.info('vérification des statuts des étapes en bdd')
@@ -55,5 +55,3 @@ const etapeStatutCheck = async () => {
   })
   console.info(`erreurs : ${errorsNb} statuts inconnus`)
 }
-
-export { etapeStatutCheck }

--- a/packages/api/src/tools/demarches/tde-check.ts
+++ b/packages/api/src/tools/demarches/tde-check.ts
@@ -2,7 +2,7 @@ import { titresTypesDemarchesTypesEtapesTypesGet } from '../../database/queries/
 import { titresDemarchesGet } from '../../database/queries/titres-demarches'
 import { userSuper } from '../../database/user-super'
 
-const titreTypeDemarcheTypeEtapeTypeCheck = async () => {
+export const titreTypeDemarcheTypeEtapeTypeCheck = async () => {
   console.info()
   console.info('- - -')
   console.info('vérification de TDE avec les démarches en bdd')
@@ -47,5 +47,3 @@ const titreTypeDemarcheTypeEtapeTypeCheck = async () => {
   })
   console.info(`erreurs : ${errorsNb} TDE inconnus`)
 }
-
-export { titreTypeDemarcheTypeEtapeTypeCheck }

--- a/packages/api/src/tools/dir-delete.ts
+++ b/packages/api/src/tools/dir-delete.ts
@@ -2,7 +2,7 @@ import { rm } from 'fs'
 
 import errorLog from './error-log'
 
-const dirDelete = async (name: string) =>
+export const dirDelete = async (name: string) =>
   new Promise((resolve, reject) => {
     rm(name, { recursive: true }, (err: any) => {
       if (err) {
@@ -18,5 +18,3 @@ const dirDelete = async (name: string) =>
       resolve(log)
     })
   })
-
-export { dirDelete }

--- a/packages/api/src/tools/documents/_types.ts
+++ b/packages/api/src/tools/documents/_types.ts
@@ -1,5 +1,3 @@
 import { IDocument, Index } from '../../types'
 
-type IndexFile = Index<{ document: IDocument; path: string }>
-
-export { IndexFile }
+export type IndexFile = Index<{ document: IDocument; path: string }>

--- a/packages/api/src/tools/documents/_utils.ts
+++ b/packages/api/src/tools/documents/_utils.ts
@@ -2,7 +2,11 @@ import { Index } from '../../types'
 
 const hashGet = (str: string) => str.split('-').pop()
 
-const matchFuzzy = (name: string, index: Index<any>, partGet = hashGet) => {
+export const matchFuzzy = (
+  name: string,
+  index: Index<any>,
+  partGet = hashGet
+) => {
   const hash = name.split('-').pop()
 
   return Object.keys(index).reduce((r: string[], key) => {
@@ -20,5 +24,3 @@ const matchFuzzy = (name: string, index: Index<any>, partGet = hashGet) => {
     return r
   }, [])
 }
-
-export { matchFuzzy }

--- a/packages/api/src/tools/documents/clean.ts
+++ b/packages/api/src/tools/documents/clean.ts
@@ -5,7 +5,7 @@ import { documentSupprimer } from '../../api/graphql/resolvers/documents'
 import { userSuper } from '../../database/user-super'
 import { datesDiffInDays } from 'camino-common/src/date'
 
-const documentsClean = async () => {
+export const documentsClean = async () => {
   console.info()
   console.info('- - -')
   console.info('suppression des documents orphelins')
@@ -31,5 +31,3 @@ const documentsClean = async () => {
     } catch (e) {}
   }
 }
-
-export { documentsClean }

--- a/packages/api/src/tools/documents/document-path-find.ts
+++ b/packages/api/src/tools/documents/document-path-find.ts
@@ -2,7 +2,10 @@ import { IDocument } from '../../types'
 import { documentRepertoireFind } from './document-repertoire-find'
 import dirCreate from '../dir-create'
 
-const documentFilePathFind = async (document: IDocument, creation = false) => {
+export const documentFilePathFind = async (
+  document: IDocument,
+  creation = false
+) => {
   const repertoire = documentRepertoireFind(document)
 
   const parentId =
@@ -20,5 +23,3 @@ const documentFilePathFind = async (document: IDocument, creation = false) => {
 
   return `${dirPath}/${document.id}.${document.fichierTypeId}`
 }
-
-export { documentFilePathFind }

--- a/packages/api/src/tools/documents/document-repertoire-find.ts
+++ b/packages/api/src/tools/documents/document-repertoire-find.ts
@@ -1,6 +1,8 @@
 import { IDocument, IDocumentRepertoire } from '../../types'
 
-const documentRepertoireFind = (document: IDocument): IDocumentRepertoire => {
+export const documentRepertoireFind = (
+  document: IDocument
+): IDocumentRepertoire => {
   if (document.titreActiviteId) {
     return 'activites'
   }
@@ -15,5 +17,3 @@ const documentRepertoireFind = (document: IDocument): IDocumentRepertoire => {
 
   return 'tmp'
 }
-
-export { documentRepertoireFind }

--- a/packages/api/src/tools/documents/documents-files-check.ts
+++ b/packages/api/src/tools/documents/documents-files-check.ts
@@ -2,7 +2,7 @@ import { Index } from '../../types'
 import { IndexFile } from './_types'
 import { matchFuzzy } from './_utils'
 
-const documentsFilesCheck = (
+export const documentsFilesCheck = (
   documentsIndex: IndexFile,
   filesIndex: Index<string>
 ) => {
@@ -35,5 +35,3 @@ const documentsFilesCheck = (
     )
   }
 }
-
-export { documentsFilesCheck }

--- a/packages/api/src/tools/documents/documents-index-build.ts
+++ b/packages/api/src/tools/documents/documents-index-build.ts
@@ -23,7 +23,7 @@ const documentPathGet = (document: IDocument) => {
   return `${path}/${document.id}.${document.fichierTypeId}`
 }
 
-const documentsIndexBuild = async () => {
+export const documentsIndexBuild = async () => {
   const documents = await documentsGet({}, {}, userSuper)
 
   return documents.reduce((res: IndexFile, document) => {
@@ -34,5 +34,3 @@ const documentsIndexBuild = async () => {
     return res
   }, {})
 }
-
-export { documentsIndexBuild }

--- a/packages/api/src/tools/email-check.ts
+++ b/packages/api/src/tools/email-check.ts
@@ -1,5 +1,4 @@
 import emailRegex from 'email-regex'
 
-const emailCheck = (email: string) => emailRegex({ exact: true }).test(email)
-
-export { emailCheck }
+export const emailCheck = (email: string) =>
+  emailRegex({ exact: true }).test(email)

--- a/packages/api/src/tools/file-name-create.ts
+++ b/packages/api/src/tools/file-name-create.ts
@@ -1,4 +1,4 @@
-const fileNameCreate = (name: string, type: string) => {
+export const fileNameCreate = (name: string, type: string) => {
   const d = new Date()
   const dd = d.getDate().toString().padStart(2, '0')
   const mm = (d.getMonth() + 1).toString().padStart(2, '0')
@@ -8,5 +8,3 @@ const fileNameCreate = (name: string, type: string) => {
 
   return `${yyyy}${mm}${dd}-${hh}h${mi}-camino-${name}.${type}`
 }
-
-export { fileNameCreate }

--- a/packages/api/src/tools/geo-convert.ts
+++ b/packages/api/src/tools/geo-convert.ts
@@ -2,7 +2,7 @@ import proj4 from 'proj4'
 import { ICoordonnees } from '../types'
 import { GEO_SYSTEME_IDS, GeoSystemeId } from 'camino-common/src/geoSystemes'
 
-const geoConvert = (
+export const geoConvert = (
   epsgId: GeoSystemeId,
   coords: ICoordonnees
 ): ICoordonnees => {
@@ -15,5 +15,3 @@ const geoConvert = (
 
   return proj4(fromProjection, toProjection, coords)
 }
-
-export { geoConvert }

--- a/packages/api/src/tools/geojson.ts
+++ b/packages/api/src/tools/geojson.ts
@@ -8,7 +8,7 @@ import { knex } from '../knex'
 // convertit des points
 // en un geojson de type 'MultiPolygon'
 
-const geojsonFeatureMultiPolygon = (points: ITitrePoint[]) => ({
+export const geojsonFeatureMultiPolygon = (points: ITitrePoint[]) => ({
   type: 'Feature',
   properties: { etapeId: points[0].titreEtapeId },
   coordinates: [],
@@ -24,7 +24,7 @@ const geojsonFeatureMultiPolygon = (points: ITitrePoint[]) => ({
 // convertit des points
 // en un geojson de type 'FeatureCollection' de 'Points'
 
-const geojsonFeatureCollectionPoints = (points: ITitrePoint[]) => ({
+export const geojsonFeatureCollectionPoints = (points: ITitrePoint[]) => ({
   type: 'FeatureCollection',
   properties: { etapeId: points[0].titreEtapeId },
   features: points.map(p => ({
@@ -78,13 +78,13 @@ const multiPolygonContoursClose = (groupes: number[][][][]) =>
     }, [])
   )
 
-const geojsonCenter = (points: ITitrePoint[]) => {
+export const geojsonCenter = (points: ITitrePoint[]) => {
   const geojson = geojsonFeatureMultiPolygon(points)
 
   return center(geojson).geometry.coordinates
 }
 
-const geojsonSurface = async (geojson: Feature<any>) => {
+export const geojsonSurface = async (geojson: Feature<any>) => {
   const result: { rows: { area: number }[] } = await knex.raw(
     `select ST_AREA(
     ST_GeomFromGeoJSON('${JSON.stringify(geojson.geometry)}'), true) as area`
@@ -92,11 +92,4 @@ const geojsonSurface = async (geojson: Feature<any>) => {
   const area = result.rows[0].area
 
   return Number.parseFloat((area / 1000000).toFixed(2))
-}
-
-export {
-  geojsonFeatureMultiPolygon,
-  geojsonFeatureCollectionPoints,
-  geojsonCenter,
-  geojsonSurface
 }

--- a/packages/api/src/tools/index.ts
+++ b/packages/api/src/tools/index.ts
@@ -2,7 +2,7 @@ import { serialize, deserialize } from 'v8'
 
 import { Index } from '../types'
 
-const dupRemove = (key: string, ...arrays: Index<any>[][]) =>
+export const dupRemove = (key: string, ...arrays: Index<any>[][]) =>
   arrays.reduce(
     (result, array) =>
       array.reduce((res: Index<any>[], el) => {
@@ -15,14 +15,17 @@ const dupRemove = (key: string, ...arrays: Index<any>[][]) =>
     []
   )
 
-const dupFind = (key: string, ...arrays: Index<any>[][]) =>
+export const dupFind = (key: string, ...arrays: Index<any>[][]) =>
   arrays.reduce(
     (result: Index<any>[], array) =>
       result.filter(el => array.find(e => e[key] && e[key] === el[key])),
     arrays.pop() as Index<any>[]
   )
 
-const objectsDiffer = (a: Index<any> | any, b: Index<any> | any): boolean => {
+export const objectsDiffer = (
+  a: Index<any> | any,
+  b: Index<any> | any
+): boolean => {
   const comparator = (a: Index<any> | any, b: Index<any> | any) =>
     Object.keys(a).find(k => {
       if (a[k] && b[k]) {
@@ -45,6 +48,4 @@ const objectsDiffer = (a: Index<any> | any, b: Index<any> | any): boolean => {
   return comparator(a, b) || comparator(b, a)
 }
 
-const objectClone = (obj: any) => deserialize(serialize(obj))
-
-export { objectClone, dupRemove, dupFind, objectsDiffer }
+export const objectClone = (obj: any) => deserialize(serialize(obj))

--- a/packages/api/src/tools/matomo.ts
+++ b/packages/api/src/tools/matomo.ts
@@ -1,6 +1,6 @@
 import MatomoTracker from 'matomo-tracker'
 
-const matomo =
+export const matomo =
   process.env.API_MATOMO_ID &&
   Number(process.env.API_MATOMO_ID) &&
   process.env.API_MATOMO_URL
@@ -10,5 +10,3 @@ const matomo =
         false
       )
     : null
-
-export { matomo }


### PR DESCRIPTION
J'ai joué avec les macros d'intelliJ un petit peu.

On gagne du temps, mais ça reste super lent. Il faudrait un truc automatique qui ungroup les export mais je ne sais pas trop comment chercher ça par mots clefs.

J'ai trouvé une règle eslint qui fait l'inverse... https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/group-exports.md
