### PR TITLE
fix(daily): récupère la liste des fichiers présents sur le disque

### DIFF
--- a/packages/api/src/tools/documents/files-index-build.ts
+++ b/packages/api/src/tools/documents/files-index-build.ts
@@ -3,9 +3,7 @@ import { basename } from 'path'
 
 import { Index } from '../../types'
 
-export const filesIndexBuild = (
-  path = './packages/api/files'
-): Index<string> => {
+export const filesIndexBuild = (path = './files'): Index<string> => {
   const filesNames = execSync(`find ${path} | grep pdf`).toString().split('\n')
 
   return filesNames.reduce((res: Index<string>, fileName) => {


### PR DESCRIPTION
Le daily plante sauvagement avec 
```
2022-08-30 02:04:30 [error] Erreur durant le daily Error: Command failed: find ./packages/api/files | grep pdf
find: ./packages/api/files: No such file or directory

    at checkExecSyncError (node:child_process:851:11)
    at execSync (node:child_process:923:15)
    at filesIndexBuild (/packages/api/dist/src/tools/documents/files-index-build.js:7:53)
    at documentsCheck (/packages/api/dist/src/tools/documents/check.js:14:64)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async tasks (/packages/api/dist/src/daily_tasks.js:54:9) {
  status: 1,
  signal: null,
  output: [
    null,
    <Buffer >,
    <Buffer 66 69 6e 64 3a 20 2e 2f 70 61 63 6b 61 67 65 73 2f 61 70 69 2f 66 69 6c 65 73 3a 20 4e 6f 20 73 75 63 68 20 66 69 6c 65 20 6f 72 20 64 69 72 65 63 74 ... 4 more bytes>
  ],
  pid: 367,
  stdout: <Buffer >,
  stderr: <Buffer 66 69 6e 64 3a 20 2e 2f 70 61 63 6b 61 67 65 73 2f 61 70 69 2f 66 69 6c 65 73 3a 20 4e 6f 20 73 75 63 68 20 66 69 6c 65 20 6f 72 20 64 69 72 65 63 74 ... 4 more bytes>
}
```