### PR TITLE
chore(infra): Installe une version figée de docker sur les machines

### DIFF
--- a/infra/deploy.yml
+++ b/infra/deploy.yml
@@ -2,13 +2,8 @@
 - hosts: servers
   vars:
     git_user_uid: 1002
-  tasks:
-    - name: Install rsync
-      ansible.builtin.apt:
-        name: rsync
-        state: present
-      become: True
   roles:
+    - role: init
     - role: user
     - role: nginx
     - role: camino

--- a/infra/roles/init/tasks/main.yml
+++ b/infra/roles/init/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Upgrade machine
+  ansible.builtin.apt:
+    upgrade: safe
+    update_cache: yes
+  become: True
+- name: Install rsync
+  ansible.builtin.apt:
+    name: rsync
+    state: present
+  become: True
+- name: Install docker
+  ansible.builtin.apt:
+    name: docker-ce=5:20.10.17~3-0~debian-buster
+  become: True
+- name: Install docker client
+  ansible.builtin.apt:
+    name: docker-ce-cli=5:20.10.17~3-0~debian-buster
+  become: True


### PR DESCRIPTION
On se retrouve avec des inconsistences entre les machines de dev, preprod et prod, où preprod et prod sont de très vieilles versions de docker

