### PR TITLE
fix(objection): place les données géographique de postgis en dehors d'Objection...

### DIFF
--- a/packages/api/src/business/processes/titres-etapes-areas-update.test.integration.ts
+++ b/packages/api/src/business/processes/titres-etapes-areas-update.test.integration.ts
@@ -33,30 +33,51 @@ describe('titresEtapesAreasUpdate', () => {
     const baisieuxId = '59044'
     const saintElieId = '97358'
     await knex!.raw(
-      `insert into communes (nom, id, departement_id, geometry) values ('Saint-Élie', '${saintElieId}', '973','${SaintEliePerimetre}')`
+      `insert into communes (nom, id, departement_id) values ('Saint-Élie', '${saintElieId}', '973')`
     )
     await knex!.raw(
-      `insert into communes (nom, id, departement_id, geometry) values ('Baisieux', '${baisieuxId}', '59', '${BaisieuxPerimetre}')`
+      `insert into communes (nom, id, departement_id) values ('Baisieux', '${baisieuxId}', '59')`
     )
     await knex!.raw(
-      `insert into communes (nom, id, departement_id, geometry) values ('Sinnamary', '97312', '973', '${SinnamaryPerimetre}')`
+      `insert into communes (nom, id, departement_id) values ('Sinnamary', '97312', '973')`
+    )
+    await knex!.raw(
+      `insert into communes_postgis (id, geometry) values ('${saintElieId}','${SaintEliePerimetre}')`
+    )
+    await knex!.raw(
+      `insert into communes_postgis (id, geometry) values ('${baisieuxId}', '${BaisieuxPerimetre}')`
+    )
+    await knex!.raw(
+      `insert into communes_postgis (id, geometry) values ('97312', '${SinnamaryPerimetre}')`
     )
 
     const reginaId = 'FRG'
     const deuxBranchesId = 'DBR'
     await knex!.raw(
-      `insert into forets (nom, id, geometry) values ('Deux Branches', '${deuxBranchesId}','${foret2BranchesPerimetre}')`
+      `insert into forets (nom, id) values ('Deux Branches', '${deuxBranchesId}')`
     )
     await knex!.raw(
-      `insert into forets (nom, id, geometry) values ('Regina', '${reginaId}','${foretReginaPerimetre}')`
+      `insert into forets (nom, id) values ('Regina', '${reginaId}')`
+    )
+    await knex!.raw(
+      `insert into forets_postgis (id, geometry) values ('${deuxBranchesId}','${foret2BranchesPerimetre}')`
+    )
+    await knex!.raw(
+      `insert into forets_postgis (id, geometry) values ('${reginaId}','${foretReginaPerimetre}')`
     )
 
     // Pour simplifier le test, on utilise des forêts en tant que zone de sdom
     await knex!.raw(
-      `insert into sdom_zones (nom, id, geometry) values ('Zone 1', '${SDOMZoneId.Zone1}','${foret2BranchesPerimetre}')`
+      `insert into sdom_zones (nom, id) values ('Zone 1', '${SDOMZoneId.Zone1}')`
     )
     await knex!.raw(
-      `insert into sdom_zones (nom, id, geometry) values ('Zone 2', '${SDOMZoneId.Zone2}','${foretReginaPerimetre}')`
+      `insert into sdom_zones (nom, id) values ('Zone 2', '${SDOMZoneId.Zone2}')`
+    )
+    await knex!.raw(
+      `insert into sdom_zones_postgis (id, geometry) values ('${SDOMZoneId.Zone1}','${foret2BranchesPerimetre}')`
+    )
+    await knex!.raw(
+      `insert into sdom_zones_postgis (id, geometry) values ('${SDOMZoneId.Zone2}','${foretReginaPerimetre}')`
     )
 
     const titreId = 'titreIdUniquePourMiseAJourAreas'

--- a/packages/api/src/database/models/communes.ts
+++ b/packages/api/src/database/models/communes.ts
@@ -17,14 +17,6 @@ class Communes extends Model {
       departementId: { type: 'string' }
     }
   }
-
-  // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-  // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-  static modifiers = {
-    defaultSelects(query: any) {
-      query.select('id', 'nom', 'departementId')
-    }
-  }
 }
 
 export default Communes

--- a/packages/api/src/database/models/forets.ts
+++ b/packages/api/src/database/models/forets.ts
@@ -15,14 +15,6 @@ class Forets extends Model {
       nom: { type: 'string' }
     }
   }
-
-  // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-  // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-  static modifiers = {
-    defaultSelects(query: any) {
-      query.select('id', 'nom')
-    }
-  }
 }
 
 export default Forets

--- a/packages/api/src/database/models/sdom-zones.ts
+++ b/packages/api/src/database/models/sdom-zones.ts
@@ -15,14 +15,6 @@ class SDOMZones extends Model {
       nom: { type: 'string' }
     }
   }
-
-  // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-  // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-  static modifiers = {
-    defaultSelects(query: any) {
-      query.select('id', 'nom')
-    }
-  }
 }
 
 export default SDOMZones

--- a/packages/api/src/database/models/titres-etapes.ts
+++ b/packages/api/src/database/models/titres-etapes.ts
@@ -157,11 +157,7 @@ class TitresEtapes extends Model {
           extra: ['surface']
         },
         to: 'communes.id'
-      },
-      // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-      // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-      modify: (query: any) =>
-        query.select('id', 'nom', 'departementId', 'titresCommunes.surface')
+      }
     },
 
     forets: {
@@ -174,10 +170,7 @@ class TitresEtapes extends Model {
           to: 'titresForets.foretId'
         },
         to: 'forets.id'
-      },
-      // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-      // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-      modify: 'defaultSelects'
+      }
     },
     sdomZones: {
       relation: Model.ManyToManyRelation,
@@ -189,10 +182,7 @@ class TitresEtapes extends Model {
           to: 'titres__sdomZones.sdomZoneId'
         },
         to: 'sdomZones.id'
-      },
-      // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-      // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-      modify: 'defaultSelects'
+      }
     },
     journaux: {
       relation: Model.HasManyRelation,

--- a/packages/api/src/database/models/titres.ts
+++ b/packages/api/src/database/models/titres.ts
@@ -193,11 +193,7 @@ class Titres extends Model {
           extra: ['surface']
         },
         to: 'communes.id'
-      },
-      // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-      // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-      modify: (query: any) =>
-        query.select('id', 'nom', 'departementId', 'titresCommunes.surface')
+      }
     },
 
     forets: {
@@ -211,10 +207,7 @@ class Titres extends Model {
           to: 'titresForets.foretId'
         },
         to: 'forets.id'
-      },
-      // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-      // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-      modify: 'defaultSelects'
+      }
     },
     sdomZones: {
       relation: Model.ManyToManyRelation,
@@ -226,10 +219,7 @@ class Titres extends Model {
           to: 'titres__sdomZones.sdomZoneId'
         },
         to: 'sdomZones.id'
-      },
-      // Attention, ici, c'est un ugly hack pour ne pas retourner le champ geometry, qui est énorme et fait des oom...
-      // Ça veut dire que si vous ajouter un champ à cette table, il faut le rajouter en dessous, sinon il n'apparaitra pas
-      modify: 'defaultSelects'
+      }
     },
 
     activites: {

--- a/packages/api/src/knex/migrations-schema/20220905073826_deplace-donnees-postgis-hors-objection.js
+++ b/packages/api/src/knex/migrations-schema/20220905073826_deplace-donnees-postgis-hors-objection.js
@@ -1,0 +1,36 @@
+exports.up = async knex => {
+  await knex.raw('alter table communes DROP COLUMN geometry')
+  await knex.raw('alter table forets DROP COLUMN geometry')
+  await knex.raw('alter table sdom_zones DROP COLUMN geometry')
+
+  await knex.raw(
+    `create table communes_postgis(
+            id varchar(5) primary key,
+            geometry geometry(Multipolygon,4326)
+        )`
+  )
+  await knex.raw(
+    `create table forets_postgis(
+            id varchar(30) primary key,
+            geometry geometry(Multipolygon,4326)
+            )`
+  )
+
+  await knex.raw(
+    `create table sdom_zones_postgis(
+            id varchar(30) primary key,
+            geometry geometry(Multipolygon,4326)
+            )`
+  )
+
+  await knex.raw(
+    'CREATE INDEX index_geo_communes on communes_postgis using spgist (geometry)'
+  )
+  await knex.raw(
+    'CREATE INDEX index_geo_forets on forets_postgis using spgist (geometry)'
+  )
+  await knex.raw(
+    'CREATE INDEX index_geo_sdom_zones on sdom_zones_postgis using spgist (geometry)'
+  )
+}
+exports.down = () => ({})

--- a/packages/api/src/tools/geojson.ts
+++ b/packages/api/src/tools/geojson.ts
@@ -106,10 +106,10 @@ export const geojsonIntersectsSDOM = async (
   let fallback = false
   try {
     result = await knex.raw(
-      `select sdom_zones.id from sdom_zones
+      `select sdom_zones_postgis.id from sdom_zones_postgis
          where ST_INTERSECTS(ST_GeomFromGeoJSON('${JSON.stringify(
            geojson.geometry
-         )}'), sdom_zones.geometry) is true`
+         )}'), sdom_zones_postgis.geometry) is true`
     )
   } catch (e) {
     fallback = true
@@ -117,10 +117,10 @@ export const geojsonIntersectsSDOM = async (
       "Une erreur est survenue lors du calcul de l'intersection avec des zones du sdom, tentative de correction automatique"
     )
     result = await knex.raw(
-      `select sdom_zones.id from sdom_zones
+      `select sdom_zones_postgis.id from sdom_zones_postgis
              where ST_INTERSECTS(ST_MAKEVALID(ST_GeomFromGeoJSON('${JSON.stringify(
                geojson.geometry
-             )}')), sdom_zones.geometry) is true`
+             )}')), sdom_zones_postgis.geometry) is true`
     )
   }
 
@@ -134,10 +134,10 @@ export const geojsonIntersectsForets = async (
   let fallback = false
   try {
     result = await knex.raw(
-      `select forets.id from forets 
+      `select forets_postgis.id from forets_postgis 
            where ST_INTERSECTS(ST_GeomFromGeoJSON('${JSON.stringify(
              geojson.geometry
-           )}'), forets.geometry) is true`
+           )}'), forets_postgis.geometry) is true`
     )
   } catch (e) {
     fallback = true
@@ -145,10 +145,10 @@ export const geojsonIntersectsForets = async (
       "Une erreur est survenue lors du calcul de l'intersection avec des forêts, tentative de correction automatique"
     )
     result = await knex.raw(
-      `select forets.id from forets 
+      `select forets_postgis.id from forets_postgis 
            where ST_INTERSECTS(ST_MAKEVALID(ST_GeomFromGeoJSON('${JSON.stringify(
              geojson.geometry
-           )}')), forets.geometry) is true`
+           )}')), forets_postgis.geometry) is true`
     )
   }
 
@@ -162,14 +162,14 @@ export const geojsonIntersectsCommunes = async (
   let fallback = false
   try {
     result = await knex.raw(
-      `select communes.id,
+      `select communes_postgis.id,
                 ST_Area(ST_INTERSECTION(ST_GeomFromGeoJSON('${JSON.stringify(
                   geojson.geometry
-                )}'), communes.geometry), true) as surface
-         from communes
+                )}'), communes_postgis.geometry), true) as surface
+         from communes_postgis
          where ST_INTERSECTS(ST_GeomFromGeoJSON('${JSON.stringify(
            geojson.geometry
-         )}'), communes.geometry) is true`
+         )}'), communes_postgis.geometry) is true`
     )
   } catch (e) {
     fallback = true
@@ -177,14 +177,14 @@ export const geojsonIntersectsCommunes = async (
       "Une erreur est survenue lors du calcul de l'intersection avec des communes, tentative de correction automatique"
     )
     result = await knex.raw(
-      `select communes.id,
+      `select communes_postgis.id,
                 ST_Area(ST_INTERSECTION(ST_MAKEVALID(ST_GeomFromGeoJSON('${JSON.stringify(
                   geojson.geometry
-                )}')), communes.geometry), true) as surface
-         from communes
+                )}')), communes_postgis.geometry), true) as surface
+         from communes_postgis
          where ST_INTERSECTS(ST_MAKEVALID(ST_GeomFromGeoJSON('${JSON.stringify(
            geojson.geometry
-         )}')), communes.geometry) is true`
+         )}')), communes_postgis.geometry) is true`
     )
   }
 


### PR DESCRIPTION
Le problème est qu'objection récupère les données même si elles ne sont pas mappées. On a tenté de faire quelque chose avec les modify_query, mais ça ne fonctionne pas.

Donc, on part sur des tables complètement séparées.
