### PR TITLE
chore(infra): simplifie le déploiement automatique

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,0 +1,115 @@
+name: API
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: 'le token pour pouvoir pousser la couverture de code'
+        required: true
+      DOCKER_USERNAME:
+        description: 'le user docker'
+        required: true
+      DOCKER_TOKEN:
+        description: 'le token docker'
+        required: true
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.7'
+          cache: 'npm'
+      - name: Npm install
+        run: |
+          npm set-script prepare ""
+          npm ci
+        env:
+          CI: true
+      - name: Lint
+        run: npm run ci:lint --workspace=packages/api
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.7'
+          cache: 'npm'
+      - name: Npm install
+        run: |
+          npm set-script prepare ""
+          npm ci
+        env:
+          CI: true
+      - name: Unit tests
+        run: npm run ci:test-unit --workspace=packages/api
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: api-unit, api
+  integration-test:
+      runs-on: ubuntu-latest
+      services:
+        postgres:
+          image: postgis/postgis:12-3.2
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: password
+            POSTGRES_DB: camino_tests
+            PGUSER: postgres
+            PGPASSWORD: password
+          options: >-
+            --health-cmd pg_isready
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+          ports:
+            # Maps tcp port 5432 on service container to the host
+            - 5432:5432
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+        - name: Use Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: '18.7'
+            cache: 'npm'
+        - name: Npm install
+          run: |
+            npm set-script prepare ""
+            npm ci
+          env:
+            CI: true
+        - name: Integration tests
+          run: npm run ci:test-integration --workspace=packages/api
+          env:
+            PGHOST: localhost
+            PGPORT: 5432
+            PGUSER: postgres
+            PGPASSWORD: password
+        - uses: codecov/codecov-action@v3
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            flags: api-integration, api
+  build:
+    needs: [unit-test, integration-test, lint]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t caminofr/camino-api:${GITHUB_SHA} -f Dockerfile.api .
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Push Docker image to the Docker Hub
+        if: github.ref == 'refs/heads/master'
+        run: docker push caminofr/camino-api:${GITHUB_SHA}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,24 @@
 name: CD
 on:
+  workflow_call:
+    inputs:
+      # Ne peut être que dev, preprod ou prod
+      deploy_environment:
+        required: true
+        type: string
+      git_sha:
+        required: true
+        type: string
+    secrets:
+      CD_TOKEN_DEV:
+        description: 'le token pour déployer en dev'
+        required: true
+      CD_TOKEN_PREPROD:
+        description: 'le token pour déployer en preprod'
+        required: true
+      CD_TOKEN_PROD:
+        description: 'le token pour déployer en prod'
+        required: true
   workflow_dispatch:
     inputs:
       deploy_environment:
@@ -15,10 +34,6 @@ on:
         description: 'Sha git à déployer'  
         type: string   
         required: true
-  workflow_run:
-    workflows: ["CI", "Release"]
-    branches: [master, release-candidate]
-    types: [completed]
 env:
   CD_TOKEN_DEV: ${{ secrets.CD_TOKEN_DEV }}
   CD_TOKEN_PREPROD: ${{ secrets.CD_TOKEN_PREPROD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,184 +7,22 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  api_unit-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.7'
-          cache: 'npm'
-      - name: Npm install
-        run: |
-          npm set-script prepare ""
-          npm ci
-        env:
-          CI: true
-      - name: Lint
-        run: npm run ci:lint --workspace=packages/api
-      - name: Unit tests
-        run: npm run ci:test-unit --workspace=packages/api
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: api-unit, api
-  api_integration-test:
-      runs-on: ubuntu-latest
-      services:
-        postgres:
-          image: postgis/postgis:12-3.2
-          env:
-            POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: password
-            POSTGRES_DB: camino_tests
-            PGUSER: postgres
-            PGPASSWORD: password
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
-          ports:
-            # Maps tcp port 5432 on service container to the host
-            - 5432:5432
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-        - name: Use Node.js
-          uses: actions/setup-node@v3
-          with:
-            node-version: '18.7'
-            cache: 'npm'
-        - name: Npm install
-          run: |
-            npm set-script prepare ""
-            npm ci
-          env:
-            CI: true
-        - name: Integration tests
-          run: npm run ci:test-integration --workspace=packages/api
-          env:
-            PGHOST: localhost
-            PGPORT: 5432
-            PGUSER: postgres
-            PGPASSWORD: password
-        - uses: codecov/codecov-action@v3
-          with:
-            token: ${{ secrets.CODECOV_TOKEN }}
-            flags: api-integration, api
-  api_build:
-    needs: [api_unit-test, api_integration-test]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build Docker image
-        run: docker build -t caminofr/camino-api:${GITHUB_SHA} -f Dockerfile.api .
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Push Docker image to the Docker Hub
-        if: github.ref == 'refs/heads/master'
-        run: docker push caminofr/camino-api:${GITHUB_SHA}
-  common_test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.7'
-          cache: 'npm'
-      - name: Npm install
-        run: |
-          npm set-script prepare ""
-          npm ci
-          npm run lint --workspace=packages/common
-        env:
-          CI: true
-      - name: Unit tests
-        run: npm run ci:test --workspace=packages/common
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: common
-
-  ui_test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.7'
-          cache: 'npm'
-      - name: Test units
-        run: |
-          npm set-script prepare ""
-          npm ci
-          npm run lint:check --workspace=packages/ui
-          npm test --workspace=packages/ui
-        env:
-          CI: true
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: ui
-
-  ui_build:
-    needs: ui_test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build Docker image
-        run: docker build . --build-arg GIT_SHA=${GITHUB_SHA} -f Dockerfile.ui -t caminofr/camino-ui:${GITHUB_SHA}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Push Docker image to the Docker Hub
-        if: github.ref == 'refs/heads/master'
-        run: docker push caminofr/camino-ui:${GITHUB_SHA}
-  ui_storybook:
-    needs: ui_test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.7'
-          cache: 'npm'
-      - name: Generate storybook
-        run: |
-          npm ci
-          npm run storybook:build -w packages/ui
-        env:
-          CI: true
-          # https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported
-          NODE_OPTIONS: --openssl-legacy-provider
-      - name: Build Docker image
-        run: docker build -f Dockerfile.ui.storybook -t caminofr/camino-ui-storybook:${GITHUB_SHA} .
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Push Docker image to the Docker Hub
-        if: github.ref == 'refs/heads/master'
-        run: docker push caminofr/camino-ui-storybook:${GITHUB_SHA}
+  ui:
+    uses: ./.github/workflows/ui.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+  api:
+    uses: ./.github/workflows/api.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+  common:
+    uses: ./.github/workflows/common.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   doc:
     runs-on: ubuntu-latest
     steps:
@@ -206,7 +44,7 @@ jobs:
       - name: Push Docker image to the Docker Hub
         if: github.ref == 'refs/heads/master'
         run: docker push caminofr/camino-api-docs:${GITHUB_SHA}
-  openfisca_build:
+  openfisca:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -221,3 +59,14 @@ jobs:
       - name: Push Docker image to the Docker Hub
         if: github.ref == 'refs/heads/master'
         run: docker push caminofr/camino-openfisca:${GITHUB_SHA}
+  deploy:
+    needs: [ui, api, common, doc, openfisca]
+    if: github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/cd.yml
+    secrets:
+      CD_TOKEN_DEV: ${{ secrets.CD_TOKEN_DEV }}
+      CD_TOKEN_PREPROD: ${{ secrets.CD_TOKEN_PREPROD }}
+      CD_TOKEN_PROD: ${{ secrets.CD_TOKEN_PROD }}
+    with:
+      deploy_environment: dev
+      git_sha: ${{ github.sha }}

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,0 +1,48 @@
+name: API
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: 'le token pour pouvoir pousser la couverture de code'
+        required: true
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.7'
+          cache: 'npm'
+      - name: Npm install
+        run: |
+          npm set-script prepare ""
+          npm ci
+        env:
+          CI: true
+      - name: Lint
+        run: npm run lint --workspace=packages/common
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.7'
+          cache: 'npm'
+      - name: Npm install
+        run: |
+          npm set-script prepare ""
+          npm ci
+        env:
+          CI: true
+      - name: Unit tests
+        run: npm run ci:test --workspace=packages/common
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: common

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -20,3 +20,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
+  deploy:
+    needs: release-github
+    uses: ./.github/workflows/cd.yml
+    secrets:
+      CD_TOKEN_DEV: ${{ secrets.CD_TOKEN_DEV }}
+      CD_TOKEN_PREPROD: ${{ secrets.CD_TOKEN_PREPROD }}
+      CD_TOKEN_PROD: ${{ secrets.CD_TOKEN_PROD }}
+    with:
+      deploy_environment: prod
+      git_sha: ${{ github.sha }}

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,98 @@
+name: UI
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: 'le token pour pouvoir pousser la couverture de code'
+        required: true
+      DOCKER_USERNAME:
+        description: 'le user docker'
+        required: true
+      DOCKER_TOKEN:
+        description: 'le token docker'
+        required: true
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.7'
+          cache: 'npm'
+      - name: Test units
+        run: |
+          npm set-script prepare ""
+          npm ci
+          npm run lint:check --workspace=packages/ui
+        env:
+          CI: true
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.7'
+          cache: 'npm'
+      - name: Test units
+        run: |
+          npm set-script prepare ""
+          npm ci
+          npm test --workspace=packages/ui
+        env:
+          CI: true
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ui
+  build:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build . --build-arg GIT_SHA=${GITHUB_SHA} -f Dockerfile.ui -t caminofr/camino-ui:${GITHUB_SHA}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Push Docker image to the Docker Hub
+        if: github.ref == 'refs/heads/master'
+        run: docker push caminofr/camino-ui:${GITHUB_SHA}
+  storybook:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.7'
+          cache: 'npm'
+      - name: Generate storybook
+        run: |
+          npm ci
+          npm run storybook:build -w packages/ui
+        env:
+          CI: true
+          # https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported
+          NODE_OPTIONS: --openssl-legacy-provider
+      - name: Build Docker image
+        run: docker build -f Dockerfile.ui.storybook -t caminofr/camino-ui-storybook:${GITHUB_SHA} .
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Push Docker image to the Docker Hub
+        if: github.ref == 'refs/heads/master'
+        run: docker push caminofr/camino-ui-storybook:${GITHUB_SHA}

--- a/Makefile
+++ b/Makefile
@@ -41,21 +41,8 @@ CD_TOKEN:=${CD_TOKEN_PROD}
 endif
 
 deploy/ci:
-ifeq ($(GITHUB_EVENT_NAME),workflow_run)
-ifeq ($(GITHUB_REF), refs/heads/master)
-	@echo "Déploiement automatique en dev"
-	@GIT_SHA=${GITHUB_SHA} CD_TOKEN=${CD_TOKEN_DEV} $(MAKE) deploy/dev
-endif
-ifeq ($(GITHUB_REF), refs/heads/release-candidate)
-	@echo "Déploiement automatique en prod"
-	@GIT_SHA=${GITHUB_SHA} CD_TOKEN=${CD_TOKEN_PROD} $(MAKE) deploy/prod
-endif
-else
-ifeq ($(GITHUB_EVENT_NAME),workflow_dispatch)
-	@echo "Déploiement manuel en ${INPUT_ENV}"
+	@echo "Déploiement de la version ${INPUT_SHA} en ${INPUT_ENV}"
 	@GIT_SHA=${INPUT_SHA} CD_TOKEN=${CD_TOKEN} $(MAKE) deploy/${INPUT_ENV}
-endif
-endif
 
 _deploy:
 ifndef DEPLOY_URL


### PR DESCRIPTION
Double objectif:
- simplifier le déploiement
- mieux découper la CI

Point bonus : On peut voir le job de déploiement directement dans le job de CI, ce n'est plus un "truc lancé en asynchrone à la fin de la CI"

![2022-10-31_15-11-42_grim](https://user-images.githubusercontent.com/414642/199030149-a8aa08b4-750b-4006-aabe-e1dce3147f82.png)
