### PR TITLE
chore(test): ajoute un test sur le statut d'une démarche d'octroi d'ARM

### DIFF
--- a/packages/api/src/business/rules-demarches/machine-helper.test.ts
+++ b/packages/api/src/business/rules-demarches/machine-helper.test.ts
@@ -14,6 +14,48 @@ describe('isEtapesOk', () => {
   })
 })
 
+describe('demarcheStatut', () => {
+  test('demarche publique et acceptée', () => {
+    expect(
+      machine.demarcheStatut([
+        {
+          date: '2020-07-27',
+          etapeTypeId: 'mfr',
+          etapeStatutId: 'fai',
+          contenu: { arm: { mecanise: true, franchissements: 1 } }
+        },
+        { date: '2021-07-27', etapeTypeId: 'mdp', etapeStatutId: 'fai' },
+        { date: '2021-07-28', etapeTypeId: 'dae', etapeStatutId: 'exe' },
+        { date: '2021-07-28', etapeTypeId: 'pfd', etapeStatutId: 'fai' },
+        { date: '2021-07-28', etapeTypeId: 'mcp', etapeStatutId: 'com' },
+        { date: '2021-07-29', etapeTypeId: 'vfd', etapeStatutId: 'fai' },
+        { date: '2021-09-16', etapeTypeId: 'mcr', etapeStatutId: 'fav' },
+        { date: '2021-09-16', etapeTypeId: 'eof', etapeStatutId: 'fai' },
+        {
+          date: '2021-12-13',
+          etapeTypeId: 'rde',
+          etapeStatutId: 'fav',
+          contenu: { arm: { franchissements: 1 } }
+        },
+        { date: '2021-12-20', etapeTypeId: 'aof', etapeStatutId: 'def' },
+        { date: '2022-02-11', etapeTypeId: 'sca', etapeStatutId: 'fai' },
+        { date: '2022-02-11', etapeTypeId: 'aca', etapeStatutId: 'ajo' },
+        { date: '2022-02-23', etapeTypeId: 'mna', etapeStatutId: 'fai' },
+        { date: '2022-03-16', etapeTypeId: 'sca', etapeStatutId: 'fai' },
+        { date: '2022-03-16', etapeTypeId: 'aca', etapeStatutId: 'fav' },
+        { date: '2022-03-31', etapeTypeId: 'mnb', etapeStatutId: 'fai' },
+        { date: '2022-04-26', etapeTypeId: 'pfc', etapeStatutId: 'fai' },
+        { date: '2022-04-26', etapeTypeId: 'vfc', etapeStatutId: 'fai' },
+        {
+          date: '2022-04-26',
+          etapeTypeId: 'sco',
+          etapeStatutId: 'fai',
+          contenu: { arm: { mecanise: true } }
+        }
+      ])
+    ).toStrictEqual({ demarcheStatut: 'acc', publique: true })
+  })
+})
 describe('whoIsBlocking', () => {
   test('on attend le PTMG pour la recevabilité d’une demande d’ARM', () => {
     expect(


### PR DESCRIPTION
En voulant analyser ce bug : https://mattermost.incubateur.net/camino/pl/76b4zrtzkjyo8dw6fg1z1wtjfr

J'ai vu qu'il manquait un test comme ça