### PR TITLE
feat(titres): affiche au publique les 'Permis Exclusifs de Carrière' dans le domaine des 'Carrières' lorsque le statut du titre est échu

### DIFF
--- a/packages/common/src/static/titresTypesTypes_domaine_titresStatuts.test.ts
+++ b/packages/common/src/static/titresTypesTypes_domaine_titresStatuts.test.ts
@@ -54,4 +54,10 @@ describe("publicité d'un titre", () => {
       titrePublicFind(TitresStatutIds.DemandeInitiale, TITRES_TYPES_TYPES_IDS.CONCESSION, DOMAINES_IDS.METAUX, [{ typeId: DEMARCHES_TYPES_IDS.MutationPartielle, publicLecture: true }])
     ).toMatchObject({ publicLecture: true })
   })
+
+  test("les permis exclusifs de carrières du domaine carrière avec une démarche d'octroi publique est publique", () => {
+    expect(
+      titrePublicFind(TitresStatutIds.Echu, TITRES_TYPES_TYPES_IDS.PERMIS_EXCLUSIF_DE_CARRIERES, DOMAINES_IDS.CARRIERES, [{ typeId: DEMARCHES_TYPES_IDS.Octroi, publicLecture: true }])
+    ).toMatchObject({ publicLecture: true })
+  })
 })

--- a/packages/common/src/static/titresTypesTypes_domaine_titresStatuts.ts
+++ b/packages/common/src/static/titresTypesTypes_domaine_titresStatuts.ts
@@ -60,7 +60,7 @@ const titresPublicLecture: { [key in TitreTypeTypeId]?: { [key in DomaineId]?: T
     [DOMAINES_IDS.GRANULATS_MARINS]: [TitresStatutIds.DemandeInitiale, TitresStatutIds.ModificationEnInstance, TitresStatutIds.Valide]
   },
   [TITRES_TYPES_TYPES_IDS.PERMIS_EXCLUSIF_DE_CARRIERES]: {
-    [DOMAINES_IDS.CARRIERES]: [TitresStatutIds.DemandeInitiale, TitresStatutIds.ModificationEnInstance, TitresStatutIds.Valide]
+    [DOMAINES_IDS.CARRIERES]: [TitresStatutIds.DemandeInitiale, TitresStatutIds.Echu, TitresStatutIds.ModificationEnInstance, TitresStatutIds.Valide]
   },
   [TITRES_TYPES_TYPES_IDS.PERMIS_EXCLUSIF_DE_RECHERCHES]: {
     [DOMAINES_IDS.FOSSILES]: [TitresStatutIds.DemandeInitiale, TitresStatutIds.Echu, TitresStatutIds.ModificationEnInstance, TitresStatutIds.Valide],


### PR DESCRIPTION
- feat(titres): suppression de la table titresType--titreStatut
- feat(titres): affiche au publique les 'Permis Exclusifs de Carrière' dans le domaine des 'Carrières' lorsque le statut du titre est échu
