### PR TITLE
infra(CI/CD): simplifie la livraison en preprod et prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 on:
   push:
     branches-ignore:
-      - release-candidate
+      - preprod
+      - prod
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,12 @@
-name: Release
+name: Deploy
 on:
   push:
     branches:
-      - release-candidate
+      - prod
+      - preprod
 jobs:
   release-github:
+    if: github.ref == 'refs/heads/prod'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +22,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
-  deploy:
+  deploy-prod:
+    if: github.ref == 'refs/heads/prod'
     needs: release-github
     uses: ./.github/workflows/cd.yml
     secrets:
@@ -29,4 +32,14 @@ jobs:
       CD_TOKEN_PROD: ${{ secrets.CD_TOKEN_PROD }}
     with:
       deploy_environment: prod
+      git_sha: ${{ github.sha }}
+  deploy-preprod:
+    if: github.ref == 'refs/heads/preprod'
+    uses: ./.github/workflows/cd.yml
+    secrets:
+      CD_TOKEN_DEV: ${{ secrets.CD_TOKEN_DEV }}
+      CD_TOKEN_PREPROD: ${{ secrets.CD_TOKEN_PREPROD }}
+      CD_TOKEN_PROD: ${{ secrets.CD_TOKEN_PROD }}
+    with:
+      deploy_environment: preprod
       git_sha: ${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK: ${{ secrets.MATTERMOST_WEBHOOK }}
         run: npx semantic-release
   deploy-prod:
     if: github.ref == 'refs/heads/prod'

--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -3,7 +3,8 @@ name: GitGuardian scan
 on:
   push:
     branches-ignore:
-      - release-candidate
+      - preprod
+      - prod
       - master
 
 jobs:

--- a/docs-sources/docs/04-deploiement/01-introduction.md
+++ b/docs-sources/docs/04-deploiement/01-introduction.md
@@ -1,5 +1,23 @@
 # Déploiement de Camino
 
-- Tout commit sur master déploie automatiquement camino en dev (dev.camino.beta.gouv.fr)
-- Pour déployer en preprod, il faut déclencher manuellement le workflow https://github.com/MTES-MCT/camino/actions/workflows/cd.yml avec l'environnement de preprod et le hash de commit que l'on souhaite déployer
-- Pour déployer en prod, il suffit de faire pointer la branche `release-candidate` sur le commit que l'on souhaite déployer en production
+## DEV https://dev.camino.beta.gouv.fr
+
+> Merger une pull-request
+
+Tout push sur la branche [master](https://github.com/MTES-MCT/camino/tree/master) déclenche la [CI](https://github.com/MTES-MCT/camino/actions/workflows/ci.yml?query=branch%3Amaster), qui, en cas de succès, déclenche le déploiement.
+
+## PREPROD https://preprod.camino.beta.gouv.fr
+
+> Faire pointer la branche **preprod** sur le commit à livrer en preprod
+
+Tout push sur la branche [preprod](https://github.com/MTES-MCT/camino/tree/preprod) déclenche la [CD](https://github.com/MTES-MCT/camino/actions/workflows/deploy.yml?query=branch%3Apreprod).
+
+
+## PROD https://camino.beta.gouv.fr
+
+> Faire pointer la branche **prod** sur le commit à livrer en prod
+
+Tout push sur la branche [prod](https://github.com/MTES-MCT/camino/tree/prod) déclenche la [CD](https://github.com/MTES-MCT/camino/actions/workflows/deploy.yml?query=branch%3Aprod).
+Avant de déployer, une [release github](https://github.com/MTES-MCT/camino/releases) est faite, qui contiendra toutes les features/bugfixes embarqués dans cette livraison depuis la version précédente
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@types/react": "file:stub/types__react",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
-        "semantic-release": "^19.0.4"
+        "semantic-release": "^19.0.4",
+        "semantic-release-mattermost": "^1.1.1"
       },
       "engines": {
         "node": ">=19.1.0",
@@ -25712,6 +25713,24 @@
       },
       "engines": {
         "node": ">=16 || ^14.17"
+      }
+    },
+    "node_modules/semantic-release-mattermost": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/semantic-release-mattermost/-/semantic-release-mattermost-1.1.1.tgz",
+      "integrity": "sha512-EGNA/E3UyNlngxaNtR8iOZtghdS9btU1lL+u3OoFtOLR559fcQGiLs1ssxK2hjWPNa7adifI6Ip9XnF+s2FlLg==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.21.4"
+      }
+    },
+    "node_modules/semantic-release-mattermost/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/semantic-release/node_modules/emoji-regex": {
@@ -52890,6 +52909,26 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
           "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
+        }
+      }
+    },
+    "semantic-release-mattermost": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/semantic-release-mattermost/-/semantic-release-mattermost-1.1.1.tgz",
+      "integrity": "sha512-EGNA/E3UyNlngxaNtR8iOZtghdS9btU1lL+u3OoFtOLR559fcQGiLs1ssxK2hjWPNa7adifI6Ip9XnF+s2FlLg==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.4"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "@types/react": "file:stub/types__react",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
-    "semantic-release": "^19.0.4"
+    "semantic-release": "^19.0.4",
+    "semantic-release-mattermost": "^1.1.1"
   },
   "release": {
     "branches": [
@@ -54,7 +55,8 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/github"
+      "@semantic-release/github",
+      "semantic-release-mattermost"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "release": {
     "branches": [
-      "release-candidate"
+      "prod"
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
L'idée est d'avoir deux branches : `preprod` et `prod` (à la place de `release-candidate`) pour déployer en preprod et en prod.

Ça sera, amha, plus simple de savoir quelle version est en preprod et en prod depuis notre repo github.

Point bonus, on a la notif sur notre channel quand la release est faite

fix #303 
