### PR TITLE
fix(api): la creation d'une étape avec une durée héritée ignore la durée de l'étape

### DIFF
--- a/packages/api/src/business/validations/titre-etape-updation-validate.ts
+++ b/packages/api/src/business/validations/titre-etape-updation-validate.ts
@@ -64,6 +64,7 @@ export const titreEtapeUpdationValidate = (
   errors.push(...errorsHeritageContenu)
 
   if (
+    !(titreEtape.heritageProps?.duree?.actif ?? false) &&
     !canEditDuree(titre.typeId, titreDemarche.typeId) &&
     (titreEtape.duree ?? 0) !== (titreEtapeOld?.duree ?? 0)
   ) {


### PR DESCRIPTION
Bug découvert par Floriane, elle ne pouvait plus déclarer l'avis de la CARM
