### PR TITLE
chore(infra): déplace les linteurs dans le makefile

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: '19.1'
           cache: 'npm'
-      - name: Npm install
+      - name: Install
         run: make install
       - name: Build
         run: make build/api
@@ -36,10 +36,10 @@ jobs:
         with:
           node-version: '19.1'
           cache: 'npm'
-      - name: Npm install
+      - name: Install
         run: make install
       - name: Lint
-        run: npm run ci:lint --workspace=packages/api
+        run: make lint/api
   unit-test:
     runs-on: ubuntu-latest
     steps:
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version: '19.1'
           cache: 'npm'
-      - name: Npm install
+      - name: Install
         run: make install
       - name: Unit tests
         run: make test/api-unit

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           node-version: '19.1'
           cache: 'npm'
-      - name: Npm install
+      - name: Install
         run: make install
       - name: Lint
-        run: npm run lint --workspace=packages/common
+        run: make lint/common
   test:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: '19.1'
           cache: 'npm'
-      - name: Npm install
+      - name: Install
         run: make install
       - name: Unit tests
         run: make test/common

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -22,10 +22,11 @@ jobs:
         with:
           node-version: '19.1'
           cache: 'npm'
-      - name: Test units
-        run: |
-          make install
-          npm run lint:check --workspace=packages/ui
+      - name: Install
+        run:  make install
+      - name: Lint
+        run: make lint/ui
+          
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,33 @@ else
 	npm run test:integration -w packages/api -- --coverage
 endif
 
+lint/ui:
+ifndef CI
+	npm run lint --workspace=packages/ui
+else
+	npm run lint:check --workspace=packages/ui
+endif
+
+
+lint/api:
+ifndef CI
+	npm run lint --workspace=packages/api
+else
+	npm run ci:lint --workspace=packages/api
+endif
+
+
+
+lint/common:
+ifndef CI
+	npm run format --workspace=packages/common
+else
+	npm run lint --workspace=packages/common
+endif
+	
+
+lint: lint/ui lint/api lint/common
+
 install:
 ifdef CI
 	npm pkg delete scripts

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "vitest --environment node --root src/",
     "build": "tsc",
-    "format": "prettier --write src",
-    "lint": "eslint --fix"
+    "format": "prettier --write src && eslint --fix src",
+    "lint": "prettier --check src && eslint src"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.34.0",


### PR DESCRIPTION
Problème : 
Chaque module a sa propre commande pour lancer le linteur.

Solution : 
On utilise la completion de Make pour faire `make lint/<tab><tab>` et voir sur quel module on lance le linteur