### PR TITLE
fix(matrices): le nom de la matrice 1402 fait apparaitre le nom de l'entreprise avant le slug

### DIFF
--- a/packages/api/src/business/matrices.ts
+++ b/packages/api/src/business/matrices.ts
@@ -818,7 +818,7 @@ export const matrices = async (annee: number) => {
                 return console.error(err)
               }
               fs.writeFileSync(
-                `1402_${annee}_${matriceLine.sip}_${matriceLine.index}_${matriceLine.titreLabel}_${matriceLine.titulaire.nom}.ods`,
+                `1402_${annee}_${matriceLine.sip}_${matriceLine.index}_${matriceLine.titulaire.nom}_${matriceLine.titreLabel}.ods`,
                 result
               )
               resolve()


### PR DESCRIPTION
Retour réunion dgfip
