### PR TITLE
feat(titre): filtre par communes, départements, régions, pays et façades maritimes

### DIFF
--- a/packages/api/src/api/graphql/resolvers/titres.ts
+++ b/packages/api/src/api/graphql/resolvers/titres.ts
@@ -20,6 +20,10 @@ import {
   assertsCanCreateTitre,
   canDeleteTitre
 } from 'camino-common/src/permissions/titres.js'
+import { DepartementId } from 'camino-common/src/static/departement.js'
+import { RegionId } from 'camino-common/src/static/region.js'
+import { PaysId } from 'camino-common/src/static/pays.js'
+import { FacadesMaritimes } from 'camino-common/src/static/facades.js'
 
 const titre = async (
   { id }: { id: string },
@@ -58,6 +62,11 @@ const titres = async (
     entreprises,
     references,
     territoires,
+    communes,
+    departements,
+    regions,
+    pays,
+    facadesMaritimes,
     demandeEnCours
   }: {
     intervalle?: number | null
@@ -76,6 +85,11 @@ const titres = async (
     entreprises: string
     references: string
     territoires: string
+    communes: string
+    departements: DepartementId[]
+    regions: RegionId[]
+    pays: PaysId[]
+    facadesMaritimes: FacadesMaritimes[]
     demandeEnCours: boolean | null
   },
   { user }: Context,
@@ -102,6 +116,11 @@ const titres = async (
           entreprises,
           references,
           territoires,
+          communes,
+          departements,
+          regions,
+          pays,
+          facadesMaritimes,
           demandeEnCours
         },
         { fields },
@@ -119,6 +138,11 @@ const titres = async (
           entreprises,
           references,
           territoires,
+          communes,
+          departements,
+          regions,
+          pays,
+          facadesMaritimes,
           demandeEnCours
         },
         { fields: {} },

--- a/packages/api/src/api/graphql/resolvers/titres.ts
+++ b/packages/api/src/api/graphql/resolvers/titres.ts
@@ -22,7 +22,6 @@ import {
 } from 'camino-common/src/permissions/titres.js'
 import { DepartementId } from 'camino-common/src/static/departement.js'
 import { RegionId } from 'camino-common/src/static/region.js'
-import { PaysId } from 'camino-common/src/static/pays.js'
 import { FacadesMaritimes } from 'camino-common/src/static/facades.js'
 
 const titre = async (
@@ -65,7 +64,6 @@ const titres = async (
     communes,
     departements,
     regions,
-    pays,
     facadesMaritimes,
     demandeEnCours
   }: {
@@ -88,7 +86,6 @@ const titres = async (
     communes: string
     departements: DepartementId[]
     regions: RegionId[]
-    pays: PaysId[]
     facadesMaritimes: FacadesMaritimes[]
     demandeEnCours: boolean | null
   },
@@ -119,7 +116,6 @@ const titres = async (
           communes,
           departements,
           regions,
-          pays,
           facadesMaritimes,
           demandeEnCours
         },
@@ -141,7 +137,6 @@ const titres = async (
           communes,
           departements,
           regions,
-          pays,
           facadesMaritimes,
           demandeEnCours
         },

--- a/packages/api/src/api/graphql/schemas/index.graphql
+++ b/packages/api/src/api/graphql/schemas/index.graphql
@@ -58,7 +58,6 @@ type Query {
     communes: String
     departements: [String]
     regions: [String]
-    pays: [String]
     facadesMaritimes: [String]
     demandeEnCours: Boolean
   ): Titres

--- a/packages/api/src/api/graphql/schemas/index.graphql
+++ b/packages/api/src/api/graphql/schemas/index.graphql
@@ -55,6 +55,11 @@ type Query {
     entreprises: String
     references: String
     territoires: String
+    communes: String
+    departements: [String]
+    regions: [String]
+    pays: [String]
+    facadesMaritimes: [String]
     demandeEnCours: Boolean
   ): Titres
 

--- a/packages/api/src/api/rest/index.ts
+++ b/packages/api/src/api/rest/index.ts
@@ -35,7 +35,6 @@ import { isRole, User } from 'camino-common/src/roles.js'
 import { utilisateursFormatTable } from './format/utilisateurs.js'
 import { isDepartementId } from 'camino-common/src/static/departement.js'
 import { isRegionId } from 'camino-common/src/static/region.js'
-import { isPaysId } from 'camino-common/src/static/pays.js'
 import { isFacade } from 'camino-common/src/static/facades.js'
 
 const formatCheck = (formats: string[], format: string) => {
@@ -112,7 +111,6 @@ interface ITitresQueryInput {
   communes?: string | null
   departements?: string | null
   regions?: string | null
-  pays?: string | null
   facadesMaritimes?: string | null
   perimetre?: number[] | null
 }
@@ -134,7 +132,6 @@ export const titres = async (
       communes,
       departements,
       regions,
-      pays,
       facadesMaritimes,
       perimetre
     }
@@ -158,7 +155,6 @@ export const titres = async (
       communes,
       departements: departements?.split(',').filter(isDepartementId),
       regions: regions?.split(',').filter(isRegionId),
-      pays: pays?.split(',').filter(isPaysId),
       facadesMaritimes: facadesMaritimes?.split(',').filter(isFacade),
       perimetre,
       demandeEnCours: true

--- a/packages/api/src/api/rest/index.ts
+++ b/packages/api/src/api/rest/index.ts
@@ -33,6 +33,10 @@ import { matomo } from '../../tools/matomo.js'
 import { stringSplit } from '../../database/queries/_utils.js'
 import { isRole, User } from 'camino-common/src/roles.js'
 import { utilisateursFormatTable } from './format/utilisateurs.js'
+import { isDepartementId } from 'camino-common/src/static/departement.js'
+import { isRegionId } from 'camino-common/src/static/region.js'
+import { isPaysId } from 'camino-common/src/static/pays.js'
+import { isFacade } from 'camino-common/src/static/facades.js'
 
 const formatCheck = (formats: string[], format: string) => {
   if (!formats.includes(format)) {
@@ -105,6 +109,11 @@ interface ITitresQueryInput {
   entreprisesIds?: string | null
   references?: string | null
   territoires?: string | null
+  communes?: string | null
+  departements?: string | null
+  regions?: string | null
+  pays?: string | null
+  facadesMaritimes?: string | null
   perimetre?: number[] | null
 }
 
@@ -122,6 +131,11 @@ export const titres = async (
       entreprisesIds,
       references,
       territoires,
+      communes,
+      departements,
+      regions,
+      pays,
+      facadesMaritimes,
       perimetre
     }
   }: { query: ITitresQueryInput },
@@ -141,6 +155,11 @@ export const titres = async (
       substancesIds: substancesIds ? stringSplit(substancesIds) : null,
       references,
       territoires,
+      communes,
+      departements: departements?.split(',').filter(isDepartementId),
+      regions: regions?.split(',').filter(isRegionId),
+      pays: pays?.split(',').filter(isPaysId),
+      facadesMaritimes: facadesMaritimes?.split(',').filter(isFacade),
       perimetre,
       demandeEnCours: true
     },

--- a/packages/api/src/database/queries/_titres-filters.ts
+++ b/packages/api/src/database/queries/_titres-filters.ts
@@ -13,7 +13,7 @@ import {
   RegionId,
   regions as regionsStatic
 } from 'camino-common/src/static/region.js'
-import { isPaysId, PaysId } from 'camino-common/src/static/pays.js'
+import { isPaysId } from 'camino-common/src/static/pays.js'
 import {
   FacadesMaritimes,
   getSecteurs
@@ -49,7 +49,6 @@ export const titresFiltersQueryModify = (
     communes,
     departements,
     regions,
-    pays,
     facadesMaritimes
   }: {
     ids?: string[] | null
@@ -66,7 +65,6 @@ export const titresFiltersQueryModify = (
     communes?: string | null
     departements?: DepartementId[] | null
     regions?: RegionId[] | null
-    pays?: PaysId[] | null
     facadesMaritimes?: FacadesMaritimes[] | null
   } = {},
   q:
@@ -307,18 +305,6 @@ export const titresFiltersQueryModify = (
       ...departementsStatic
         .filter(({ regionId }) => regions.includes(regionId))
         .map(({ id }) => id)
-    )
-  }
-
-  if (pays) {
-    departementIds.push(
-      ...regionsStatic
-        .filter(({ paysId }) => pays.includes(paysId))
-        .flatMap(({ id }) =>
-          departementsStatic
-            .filter(({ regionId }) => id === regionId)
-            .map(({ id }) => id)
-        )
     )
   }
 

--- a/packages/api/src/database/queries/_titres-filters.ts
+++ b/packages/api/src/database/queries/_titres-filters.ts
@@ -340,7 +340,9 @@ export const titresFiltersQueryModify = (
     }
     q.leftJoinRelated(jointureFormat(name, 'pointsEtape'))
     q.whereRaw(
-      `?? ?| array[${secteurs.map(secteur => `'${secteur}'`).join(',')}]`,
+      `?? \\?| array[${secteurs
+        .map(secteur => `E'${secteur.replaceAll("'", "\\'")}'`)
+        .join(',')}]`,
       fieldFormat(name, 'pointsEtape.secteursMaritime')
     )
   }

--- a/packages/api/src/database/queries/titres.ts
+++ b/packages/api/src/database/queries/titres.ts
@@ -19,6 +19,10 @@ import { titresFiltersQueryModify } from './_titres-filters.js'
 import TitresDemarches from '../models/titres-demarches.js'
 import TitresEtapes from '../models/titres-etapes.js'
 import { User } from 'camino-common/src/roles'
+import { DepartementId } from 'camino-common/src/static/departement.js'
+import { RegionId } from 'camino-common/src/static/region.js'
+import { PaysId } from 'camino-common/src/static/pays.js'
+import { FacadesMaritimes } from 'camino-common/src/static/facades.js'
 
 /**
  * Construit la requête pour récupérer certains champs de titres filtrés
@@ -111,6 +115,11 @@ const titresGet = async (
     entreprises,
     references,
     territoires,
+    communes,
+    departements,
+    regions,
+    pays,
+    facadesMaritimes,
     slugs,
     demandeEnCours
   }: {
@@ -129,6 +138,11 @@ const titresGet = async (
     entreprises?: string | null
     references?: string | null
     territoires?: string | null
+    communes?: string | null
+    departements?: DepartementId[] | null
+    regions?: RegionId[] | null
+    pays?: PaysId[] | null
+    facadesMaritimes?: FacadesMaritimes[] | null
     slugs?: string[] | null
     demandeEnCours?: boolean | null
   } = {},
@@ -153,7 +167,12 @@ const titresGet = async (
       noms,
       entreprises,
       references,
-      territoires
+      territoires,
+      communes,
+      departements,
+      regions,
+      pays,
+      facadesMaritimes
     },
     q
   )
@@ -232,6 +251,11 @@ const titresCount = async (
     entreprises,
     references,
     territoires,
+    communes,
+    departements,
+    regions,
+    pays,
+    facadesMaritimes,
     demandeEnCours
   }: {
     ids?: string[] | null
@@ -244,6 +268,11 @@ const titresCount = async (
     entreprises?: string | null
     references?: string | null
     territoires?: string | null
+    communes?: string | null
+    departements?: DepartementId[] | null
+    regions?: RegionId[] | null
+    pays?: PaysId[] | null
+    facadesMaritimes?: FacadesMaritimes[] | null
     demandeEnCours?: boolean | null
   } = {},
   { fields }: { fields?: IFields },
@@ -262,7 +291,12 @@ const titresCount = async (
       noms,
       entreprises,
       references,
-      territoires
+      territoires,
+      communes,
+      departements,
+      regions,
+      pays,
+      facadesMaritimes
     },
     q
   )

--- a/packages/api/src/database/queries/titres.ts
+++ b/packages/api/src/database/queries/titres.ts
@@ -21,7 +21,6 @@ import TitresEtapes from '../models/titres-etapes.js'
 import { User } from 'camino-common/src/roles'
 import { DepartementId } from 'camino-common/src/static/departement.js'
 import { RegionId } from 'camino-common/src/static/region.js'
-import { PaysId } from 'camino-common/src/static/pays.js'
 import { FacadesMaritimes } from 'camino-common/src/static/facades.js'
 
 /**
@@ -118,7 +117,6 @@ const titresGet = async (
     communes,
     departements,
     regions,
-    pays,
     facadesMaritimes,
     slugs,
     demandeEnCours
@@ -141,7 +139,6 @@ const titresGet = async (
     communes?: string | null
     departements?: DepartementId[] | null
     regions?: RegionId[] | null
-    pays?: PaysId[] | null
     facadesMaritimes?: FacadesMaritimes[] | null
     slugs?: string[] | null
     demandeEnCours?: boolean | null
@@ -171,7 +168,6 @@ const titresGet = async (
       communes,
       departements,
       regions,
-      pays,
       facadesMaritimes
     },
     q
@@ -254,7 +250,6 @@ const titresCount = async (
     communes,
     departements,
     regions,
-    pays,
     facadesMaritimes,
     demandeEnCours
   }: {
@@ -271,7 +266,6 @@ const titresCount = async (
     communes?: string | null
     departements?: DepartementId[] | null
     regions?: RegionId[] | null
-    pays?: PaysId[] | null
     facadesMaritimes?: FacadesMaritimes[] | null
     demandeEnCours?: boolean | null
   } = {},
@@ -295,7 +289,6 @@ const titresCount = async (
       communes,
       departements,
       regions,
-      pays,
       facadesMaritimes
     },
     q

--- a/packages/common/src/static/facades.ts
+++ b/packages/common/src/static/facades.ts
@@ -73,7 +73,7 @@ const facades = {
     'Plaine orientale et large Est de la Corse': { ids: [34], secteurId: '30', departementIds: [] }
   }
 }
-const FACADES = Object.keys(facades) as FacadesMaritimes[]
+export const FACADES = Object.keys(facades) as FacadesMaritimes[]
 const SECTEURS = Object.values(facades).flatMap(f => Object.keys(f)) as SecteursMaritimes[]
 
 export type FacadesMaritimes = keyof typeof facades

--- a/packages/common/src/static/facades.ts
+++ b/packages/common/src/static/facades.ts
@@ -73,7 +73,6 @@ const facades = {
     'Plaine orientale et large Est de la Corse': { ids: [34], secteurId: '30', departementIds: [] }
   }
 }
-
 const FACADES = Object.keys(facades) as FacadesMaritimes[]
 const SECTEURS = Object.values(facades).flatMap(f => Object.keys(f)) as SecteursMaritimes[]
 
@@ -141,6 +140,11 @@ const getFacade = (secteurMaritime: SecteursMaritimes): FacadesMaritimes => {
   assertsFacade(facade)
 
   return facade
+}
+
+export const getSecteurs = (facadeMaritime: FacadesMaritimes): SecteursMaritimes[] => {
+  // TODO 2023-03-01: use getKeys instead
+  return Object.keys(facades[facadeMaritime]) as SecteursMaritimes[]
 }
 
 export const isFacade = (facade: unknown): facade is FacadesMaritimes => FACADES.includes(facade)

--- a/packages/common/src/static/pays.ts
+++ b/packages/common/src/static/pays.ts
@@ -39,8 +39,6 @@ export const PaysList: { [key in PaysId]: Pays<key> } = {
   YT: { id: 'YT', nom: 'Département de Mayotte' }
 }
 
-export const pays = Object.values(PaysList)
-
 const PAYS_IDS_LIST = Object.values(PAYS_IDS)
 
 export const isPaysId = (value: string): value is PaysId => PAYS_IDS_LIST.includes(value)

--- a/packages/common/src/static/pays.ts
+++ b/packages/common/src/static/pays.ts
@@ -39,6 +39,8 @@ export const PaysList: { [key in PaysId]: Pays<key> } = {
   YT: { id: 'YT', nom: 'Département de Mayotte' }
 }
 
+export const pays = Object.values(PaysList)
+
 const PAYS_IDS_LIST = Object.values(PAYS_IDS)
 
 export const isPaysId = (value: string): value is PaysId => PAYS_IDS_LIST.includes(value)

--- a/packages/ui/src/api/titres.js
+++ b/packages/ui/src/api/titres.js
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 import { apiGraphQLFetch } from './_client'
 
-import { fragmentTitreTypeType } from './fragments/metas'
 import {
   fragmentTitre,
   fragmentTitres,
@@ -44,7 +43,11 @@ const titresGeoPolygon = apiGraphQLFetch(
       $substancesIds: [ID!]
       $entreprisesIds: [ID!]
       $references: String
-      $territoires: String
+      $communes: String
+      $departements: [String]
+      $regions: [String]
+      $pays: [String]
+      $facadesMaritimes: [String]
       $perimetre: [Float!]
     ) {
       titres(
@@ -55,7 +58,11 @@ const titresGeoPolygon = apiGraphQLFetch(
         substancesIds: $substancesIds
         entreprisesIds: $entreprisesIds
         references: $references
-        territoires: $territoires
+        communes: $communes
+        departements: $departements
+        regions: $regions
+        pays: $pays
+        facadesMaritimes: $facadesMaritimes
         perimetre: $perimetre
         demandeEnCours: true
       ) {
@@ -80,7 +87,11 @@ const titresGeo = apiGraphQLFetch(
       $substancesIds: [ID!]
       $entreprisesIds: [ID!]
       $references: String
-      $territoires: String
+      $communes: String
+      $departements: [String]
+      $regions: [String]
+      $pays: [String]
+      $facadesMaritimes: [String]
       $perimetre: [Float!]
     ) {
       titres(
@@ -91,7 +102,11 @@ const titresGeo = apiGraphQLFetch(
         substancesIds: $substancesIds
         entreprisesIds: $entreprisesIds
         references: $references
-        territoires: $territoires
+        communes: $communes
+        departements: $departements
+        regions: $regions
+        pays: $pays
+        facadesMaritimes: $facadesMaritimes
         perimetre: $perimetre
         demandeEnCours: true
       ) {
@@ -121,7 +136,11 @@ const titres = apiGraphQLFetch(
       $noms: String
       $entreprisesIds: [ID!]
       $references: String
-      $territoires: String
+      $communes: String
+      $departements: [String]
+      $regions: [String]
+      $pays: [String]
+      $facadesMaritimes: [String]
     ) {
       titres(
         intervalle: $intervalle
@@ -136,7 +155,11 @@ const titres = apiGraphQLFetch(
         noms: $noms
         entreprisesIds: $entreprisesIds
         references: $references
-        territoires: $territoires
+        communes: $communes
+        departements: $departements
+        regions: $regions
+        pays: $pays
+        facadesMaritimes: $facadesMaritimes
       ) {
         elements {
           ...titres

--- a/packages/ui/src/api/titres.js
+++ b/packages/ui/src/api/titres.js
@@ -46,7 +46,6 @@ const titresGeoPolygon = apiGraphQLFetch(
       $communes: String
       $departements: [String]
       $regions: [String]
-      $pays: [String]
       $facadesMaritimes: [String]
       $perimetre: [Float!]
     ) {
@@ -61,7 +60,6 @@ const titresGeoPolygon = apiGraphQLFetch(
         communes: $communes
         departements: $departements
         regions: $regions
-        pays: $pays
         facadesMaritimes: $facadesMaritimes
         perimetre: $perimetre
         demandeEnCours: true
@@ -90,7 +88,6 @@ const titresGeo = apiGraphQLFetch(
       $communes: String
       $departements: [String]
       $regions: [String]
-      $pays: [String]
       $facadesMaritimes: [String]
       $perimetre: [Float!]
     ) {
@@ -105,7 +102,6 @@ const titresGeo = apiGraphQLFetch(
         communes: $communes
         departements: $departements
         regions: $regions
-        pays: $pays
         facadesMaritimes: $facadesMaritimes
         perimetre: $perimetre
         demandeEnCours: true
@@ -139,7 +135,6 @@ const titres = apiGraphQLFetch(
       $communes: String
       $departements: [String]
       $regions: [String]
-      $pays: [String]
       $facadesMaritimes: [String]
     ) {
       titres(
@@ -158,7 +153,6 @@ const titres = apiGraphQLFetch(
         communes: $communes
         departements: $departements
         regions: $regions
-        pays: $pays
         facadesMaritimes: $facadesMaritimes
       ) {
         elements {

--- a/packages/ui/src/components/titres/filtres.js
+++ b/packages/ui/src/components/titres/filtres.js
@@ -6,7 +6,6 @@ import { sortedTitresStatuts } from 'camino-common/src/static/titresStatuts'
 import { sortedTitreTypesTypes } from 'camino-common/src/static/titresTypesTypes'
 import { departements } from 'camino-common/src/static/departement'
 import { regions } from 'camino-common/src/static/region'
-import { pays } from 'camino-common/src/static/pays'
 import { FACADES } from 'camino-common/src/static/facades'
 
 const filtres = [
@@ -62,14 +61,6 @@ const filtres = [
     value: [],
     elements: regions
   },
-  {
-    id: 'pays',
-    name: 'Pays',
-    type: 'autocomplete',
-    value: [],
-    elements: pays
-  },
-
   {
     id: 'facadesMaritimes',
     name: 'Façades Maritimes',

--- a/packages/ui/src/components/titres/filtres.js
+++ b/packages/ui/src/components/titres/filtres.js
@@ -4,6 +4,10 @@ import { SubstancesLegales } from 'camino-common/src/static/substancesLegales'
 import { sortedDomaines } from 'camino-common/src/static/domaines'
 import { sortedTitresStatuts } from 'camino-common/src/static/titresStatuts'
 import { sortedTitreTypesTypes } from 'camino-common/src/static/titresTypesTypes'
+import { departements } from 'camino-common/src/static/departement'
+import { regions } from 'camino-common/src/static/region'
+import { pays } from 'camino-common/src/static/pays'
+import { FACADES } from 'camino-common/src/static/facades'
 
 const filtres = [
   {
@@ -38,11 +42,40 @@ const filtres = [
     placeholder: 'Référence DGEC, DEAL, DEB, BRGM, Ifremer, …'
   },
   {
-    id: 'territoires',
+    id: 'communes',
     type: 'input',
     value: '',
-    name: 'Territoires',
-    placeholder: 'Commune, département, région, …'
+    name: 'Communes',
+    placeholder: 'Communes'
+  },
+  {
+    id: 'departements',
+    name: 'Départements',
+    type: 'autocomplete',
+    value: [],
+    elements: departements
+  },
+  {
+    id: 'regions',
+    name: 'Régions',
+    type: 'autocomplete',
+    value: [],
+    elements: regions
+  },
+  {
+    id: 'pays',
+    name: 'Pays',
+    type: 'autocomplete',
+    value: [],
+    elements: pays
+  },
+
+  {
+    id: 'facadesMaritimes',
+    name: 'Façades Maritimes',
+    type: 'autocomplete',
+    value: [],
+    elements: FACADES.map(facade => ({ id: facade, nom: facade }))
   },
   {
     id: 'domainesIds',

--- a/packages/ui/src/store/titres.js
+++ b/packages/ui/src/store/titres.js
@@ -17,7 +17,11 @@ const getDefaultState = () => {
       { id: 'titresIds', type: 'strings', values: [] },
       { id: 'entreprisesIds', type: 'strings', values: [] },
       { id: 'references', type: 'string' },
-      { id: 'territoires', type: 'string' },
+      { id: 'communes', type: 'string' },
+      { id: 'departements', type: 'strings', values: [] },
+      { id: 'regions', type: 'strings', values: [] },
+      { id: 'pays', type: 'strings', values: [] },
+      { id: 'facadesMaritimes', type: 'strings', values: [] },
       { id: 'page', type: 'number', value: 1, min: 0 },
       { id: 'intervalle', type: 'number', min: 10, max: 500 },
       {
@@ -57,7 +61,11 @@ const getDefaultState = () => {
         titresIds: [],
         entreprisesIds: '',
         references: '',
-        territoires: ''
+        communes: '',
+        departements: [],
+        regions: [],
+        pays: [],
+        facadesMaritimes: []
       }
     },
     initialized: false

--- a/packages/ui/src/store/titres.js
+++ b/packages/ui/src/store/titres.js
@@ -20,7 +20,6 @@ const getDefaultState = () => {
       { id: 'communes', type: 'string' },
       { id: 'departements', type: 'strings', values: [] },
       { id: 'regions', type: 'strings', values: [] },
-      { id: 'pays', type: 'strings', values: [] },
       { id: 'facadesMaritimes', type: 'strings', values: [] },
       { id: 'page', type: 'number', value: 1, min: 0 },
       { id: 'intervalle', type: 'number', min: 10, max: 500 },
@@ -64,7 +63,6 @@ const getDefaultState = () => {
         communes: '',
         departements: [],
         regions: [],
-        pays: [],
         facadesMaritimes: []
       }
     },


### PR DESCRIPTION
Je ne suis pas sûr que le pays soit intéressant/pertinent car notre notion de pays est assez propre à Camino : 

```
  BL: { id: 'BL', nom: "Collectivité d'outre-mer de Saint-Barthélemy" },
  FR: { id: 'FR', nom: 'République Française' },
  GF: { id: 'GF', nom: 'Département de la Guyane' },
  GP: { id: 'GP', nom: 'Département de la Guadeloupe' },
  MF: { id: 'MF', nom: "Collectivité d'outre-mer de Saint-Martin" },
  MQ: { id: 'MQ', nom: 'Département de la Martinique' },
  NC: { id: 'NC', nom: 'Nouvelle-Calédonie' },
  PF: { id: 'PF', nom: 'Polynésie Française' },
  PM: { id: 'PM', nom: 'Collectivité Territoriale de Saint-Pierre-et-Miquelon' },
  RE: { id: 'RE', nom: 'Département de La Réunion' },
  TF: { id: 'TF', nom: 'Terres Australes Françaises' },
  WF: { id: 'WF', nom: 'Wallis-et-Futuna' },
  XX: { id: 'XX', nom: 'Clipperton (Île)' },
  YT: { id: 'YT', nom: 'Département de Mayotte' }
```

Je ne sais pas si on veut des & ou des | entre les différentes parties du filtres, j'ai l'impression que des fois ça se comporte comme des &, des fois comme des |

Related to:
  * #400
