### PR TITLE
fix(ui): le bouton de téléchargement de la donnée d'un graphe reste collé au graphe

### DIFF
--- a/packages/ui/src/components/_charts/chart-with-export.tsx
+++ b/packages/ui/src/components/_charts/chart-with-export.tsx
@@ -29,12 +29,12 @@ export const ChartWithExport = <T,>(props: Props<T>): JSX.Element => {
       data={props.data}
       renderItem={item => {
         return (
-          <>
+          <div style="position: relative">
             <ConfigurableChart chartConfiguration={props.getConfiguration(item)} />
             <button class="btn-border py-xs px-s rnd-xs" style="position: absolute; top: 4px; right: 10px" title="Export CSV" onClick={() => exportCsv(props.getConfiguration(item))}>
               <Icon size="S" name="download" />
             </button>
-          </>
+          </div>
         )
       }}
     />


### PR DESCRIPTION
## Checklist

* [ ] Ne plus voir ça sur les graphes de la DGTM

![2023-03-09_17-25-30_grim](https://user-images.githubusercontent.com/414642/224087696-d2c57ef2-6cef-4207-a3a7-9c42efb0cdd7.png)
