### PR TITLE
chore(infra): installe la dernière version de postgres (15.2) / postgis (3.3)

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -62,7 +62,7 @@ jobs:
       runs-on: ubuntu-latest
       services:
         postgres:
-          image: postgis/postgis:12-3.3
+          image: postgis/postgis:15-3.3
           env:
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: password

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -25,7 +25,7 @@ services:
       - ./.env:/.env
   db:
     container_name: camino_api_db
-    image: postgis/postgis:12-3.3
+    image: postgis/postgis:15-3.3
     environment:
       PGUSER: ${PGUSER}
       POSTGRES_USER: ${PGUSER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
   db:
     container_name: camino_api_db
-    image: postgis/postgis:12-3.3
+    image: postgis/postgis:15-3.3
     environment:
       PGUSER: ${PGUSER}
       POSTGRES_USER: ${PGUSER}


### PR DESCRIPTION
Migration manuelle à effectuer :

En dev/préprod : 

1. Lancer ansible pour déployer la nouvelle version
  * `make dev` ou `make preprod`
2. Arrêter le serveur postgres (qui doit planter en boucle normalement)
  * `docker stop camino_api_db camino_api_app camino_keycloak`
3. Supprimer le dossier des données de la BDD `sudo rm -rf /srv/www/camino/postgresql/`
4. Relancer les docker
  * `docker start camino_api_db camino_api_app camino_keycloak`
5. Relancer le script apply prod qui prend les données de prod et qui les installe sur l'environnement
  * `cd /srv/scripts && ./apply-prod`


En prod :
1. Arrêter les applicatifs
  * `docker stop camino_api_app camino_keycloak`
2. Lancer un backup
  * `cd /srv/scripts && ./backup`
3. Copier ce backup en local (au cas où)
4. Lancer ansible pour déployer la nouvelle version
  * `make prod`
5. Arrêter le conteneur postgres
  * `docker stop camino_api_db`
6. Supprimer le dossier des données de la BDD `sudo rm -rf /srv/www/camino/postgresql/`
7. Relancer le conteneur postgres
  * `docker start camino_api_db`
8. Appliquer le dump
  * `docker exec -i camino_api_db dropdb --username=postgres camino`
  * `docker exec -i camino_api_db createdb  --username=postgres camino`
  * `docker exec -i camino_api_db pg_restore --clean --if-exists --no-owner --no-privileges --dbname=camino < /srv/backups/camino.sql`
9. Relancer les docker
  * `docker start camino_api_app camino_keycloak`
