### PR TITLE
fix(document): ne peut pas supprimer un document lié à une étape

### DIFF
--- a/packages/ui/src/utils/documents.js
+++ b/packages/ui/src/utils/documents.js
@@ -34,7 +34,7 @@ const documentsRequiredAdd = (documents, documentsTypes, userIsAdmin) => {
 
   // on interdit la suppression des documents obligatoires et imcomplets
   documents?.forEach(d => {
-    d.suppression = d.id !== typeGet(d)
+    d.suppression = d.suppression && d.id !== typeGet(d)
   })
 
   return newDocuments

--- a/packages/ui/src/utils/documents.test.js
+++ b/packages/ui/src/utils/documents.test.js
@@ -33,10 +33,10 @@ describe('documents', () => {
   })
 
   test('supprime le document avec un type inexistant', () => {
-    expect(documentsRequiredAdd([{ typeId: 'aaa' }, { typeId: 'ddd' }], [{ optionnel: false, id: 'aaa' }], true)).toEqual([
+    expect(documentsRequiredAdd([{ typeId: 'aaa', suppression: false }, { typeId: 'ddd' }], [{ optionnel: false, id: 'aaa' }], true)).toEqual([
       {
         typeId: 'aaa',
-        suppression: true,
+        suppression: false,
       },
     ])
   })


### PR DESCRIPTION
- [ ] Après l’enregistrement, il n’est pas possible de supprimer un document lié à une étape (donc de voir le bouton suppression)
- [ ] On peut supprimer un document (non obligatoire) juste avant d’enregistrer