### PR TITLE
fix(ui): ne bloque plus lors de la sélection des types d'étapes

### DIFF
--- a/packages/ui/src/components/etape/type-edit.tsx
+++ b/packages/ui/src/components/etape/type-edit.tsx
@@ -110,7 +110,7 @@ export const TypeEdit = caminoDefineComponent<Props>(['etape', 'etapeDate', 'dem
                       id: 'select-etape-type',
                       type: 'single',
                       placeholder: '',
-                      items: items
+                      items: [...items]
                         .sort((a, b) => (a.mainStep ? -1 : 1))
                         .map(({ etapeTypeId }) => EtapesTypes[etapeTypeId])
                         .filter(({ nom }) => {


### PR DESCRIPTION
On voit un warn lorsqu'on dev, mais en prod, ça bloque indéfiniment....

C'est dû au sort qui est "in place" et qui passe son temps à muter la props du composant typeahead, qui se re-render en boucle.

Très sympa de la part de vue de "juste" mettre un warn dans la console et de planter lamentablement en prod...
