### PR TITLE
fix(pex): les permis d'exploitations géothermie utilisent tous la machine, sauf 3 déjà présents et invalides

### DIFF
--- a/packages/api/src/business/rules-demarches/definitions.ts
+++ b/packages/api/src/business/rules-demarches/definitions.ts
@@ -143,8 +143,14 @@ export const demarchesDefinitions: IDemarcheDefinition[] = [
     titreTypeId: 'pxg',
     demarcheTypeIds: ['oct'],
     machine: new PxgOctMachine(),
-    // https://camino.beta.gouv.fr/titres/g-px-vallee-arena-2020
-    dateDebut: toCaminoDate('2021-01-01'),
+    // Cette date est la plus ancienne trouvée en base
+    dateDebut: toCaminoDate('1717-01-09'),
+    demarcheIdExceptions: [
+      // Ne respectent pas le cacoo
+      newDemarcheId('fqDEYKmkLijEx0b7HRmkXxUP'),
+      newDemarcheId('fML5J37ugo6iWC3ugXfQ2AIk'),
+      newDemarcheId('Umr7TPPxiuGDOzzlKfu4S8Dm'),
+    ],
   },
 ]
 


### PR DESCRIPTION
## Checklist

* [ ] Parmi ces PEX Géothermie: https://preprod.camino.beta.gouv.fr/titres?vueId=table&typesIds=px&domainesIds=g&page=1&intervalle=200&ordre=asc&colonne=nom
* [ ] 3 sont invalides par rapport à l'arbre d'instruction (Be-Flex, Bouillante et Vallée Arena)
* [ ] Tous les autres sont bons (y compris les nouveaux crées)
