### PR TITLE
fix(infra): corrige la date du dernier snapshot appliqué sur l'environnement de dev

### DIFF
--- a/infra/roles/devAndPreprod/templates/apply-prod
+++ b/infra/roles/devAndPreprod/templates/apply-prod
@@ -8,6 +8,7 @@ fi
 
 echo 'Mise en place des fichiers de prod'
 rm -rf /srv/backups/*
+source /srv/scripts/restic_data
 restic restore latest --no-lock -t /
 rsync --delete -r /srv/backups/files/ /srv/www/camino/files
 echo "Arrêt de l'api et de keycloak"


### PR DESCRIPTION
On a bien reçu le message, mais sans la date du snapshot, car on a oublié de sourcer les variables restic
