### PR TITLE
feat(documents): ajoute le document 'avis' sur les étapes 'Avis du parc naturel marin' et Avis d'un président d'EPCI

### DIFF
--- a/packages/common/src/static/titresTypes_demarchesTypes_etapesTypes/documents.ts
+++ b/packages/common/src/static/titresTypes_demarchesTypes_etapesTypes/documents.ts
@@ -6,6 +6,8 @@ import { TitreTypeId, TITRES_TYPES_IDS, isTitreType } from './../titresTypes.js'
 import { TDEType } from './index.js'
 
 const EtapesTypesDocumentsTypes = {
+  [ETAPES_TYPES.avisDunPresidentDEPCI]: [DOCUMENTS_TYPES_IDS.avis],
+  [ETAPES_TYPES.avisDuParcNaturelMarin]: [DOCUMENTS_TYPES_IDS.avis],
   [ETAPES_TYPES.avisDGTMServiceMilieuxNaturelsBiodiversiteSitesEtPaysages_MNBST_]: [DOCUMENTS_TYPES_IDS.avisDesServicesCivilsEtMilitaires],
   [ETAPES_TYPES.avisDeLaDirectionDesEntreprisesDeLaConcurrenceDeLaConsommationDuTravailEtDeLemploi]: [DOCUMENTS_TYPES_IDS.avisDesServicesCivilsEtMilitaires],
   [ETAPES_TYPES.avisDeDirectionRegionaleDesAffairesCulturelles]: [DOCUMENTS_TYPES_IDS.avisDesServicesCivilsEtMilitaires, DOCUMENTS_TYPES_IDS.avis],


### PR DESCRIPTION
## Checklist

* [ ] pouvoir ajouter un document "avis" (avi) à l'étape "Avis du parc naturel marin" de façon facultative
* [ ] pouvoir ajouter un document "avis" (avi) à l'étape "Avis d'un président d'EPCI" de façon facultative


Related to https://trello.com/c/zwMPsBwl/472-permettre-lajout-de-documents-sur-certaines-%C3%A9tapes
