### PR TITLE
refactor(ui): les composants de carte sont chargés dynamiquement

### DIFF
--- a/packages/ui/src/components/_common/perimetre.stories.tsx
+++ b/packages/ui/src/components/_common/perimetre.stories.tsx
@@ -8,6 +8,7 @@ import { titreIdValidator } from 'camino-common/src/titres'
 
 const meta: Meta = {
   title: 'Components/Common/Perimetre',
+  // @ts-ignore @storybook/vue3 n'aime pas les composants tsx
   component: Perimetre,
 }
 export default meta

--- a/packages/ui/src/components/_common/perimetre.tsx
+++ b/packages/ui/src/components/_common/perimetre.tsx
@@ -1,9 +1,9 @@
 import { Point } from '@/utils/titre-etape-edit'
 import { TitreTypeId } from 'camino-common/src/static/titresTypes'
-import { FunctionalComponent } from 'vue'
+import { FunctionalComponent, defineAsyncComponent, defineComponent } from 'vue'
 import { Icon } from '../_ui/icon'
 import { Icon as IconSprite } from '../_ui/iconSpriteType'
-import { CaminoCommonMap, Props as CaminoCommonMapProps } from './map'
+import type { Props as CaminoCommonMapProps } from './map'
 import { Points } from './points'
 import { TitreId } from 'camino-common/src/titres'
 import { ButtonIcon } from '../_ui/button-icon'
@@ -27,11 +27,15 @@ const tabs: { id: TabId; nom: Capitalize<TabId>; icon: IconSprite }[] = [
   { id: 'points', nom: 'Points', icon: 'list' },
 ]
 
-export const Perimetre: FunctionalComponent<Props> = (props: Props) => {
+export const Perimetre = defineComponent<Props>((props: Props) => {
   const isMain = props.isMain ?? false
   const tabId = props.tabId ?? 'carte'
   const titreId = props.titreId ?? ''
-  return (
+  const CaminoCommonMap = defineAsyncComponent(async () => {
+    const { CaminoCommonMap } = await import('./map')
+    return CaminoCommonMap
+  })
+  return () => (
     <div>
       <div class="tablet-blobs tablet-flex-direction-reverse dsfr" style={{ alignItems: 'center' }}>
         <div class="tablet-blob-1-2" style={{ display: 'flex', flexDirection: 'row-reverse' }}>
@@ -97,4 +101,7 @@ export const Perimetre: FunctionalComponent<Props> = (props: Props) => {
       <div class={`${isMain ? 'width-full' : ''} line mb`} />
     </div>
   )
-}
+})
+
+// @ts-ignore waiting for https://github.com/vuejs/core/issues/7833
+Perimetre.props = ['points', 'geojsonMultiPolygon', 'titreTypeId', 'titreId', 'isMain', 'tabId', 'tabUpdate', 'loading']

--- a/packages/ui/src/components/_map/index.tsx
+++ b/packages/ui/src/components/_map/index.tsx
@@ -3,6 +3,7 @@ import type { LatLngBoundsExpression, LatLngExpression, Map, Layer, LayersContro
 import { ref, onMounted, markRaw, watch } from 'vue'
 import { FeatureGroup, LayerGroup, layerGroup } from 'leaflet'
 import { caminoDefineComponent } from '@/utils/vue-tsx-utils'
+import { displayPerimeterZoomMaxLevel } from './util'
 
 export interface Props {
   markerLayers: Layer[]
@@ -11,8 +12,6 @@ export interface Props {
   additionalOverlayLayers?: Record<string, LayerGroup>
   loading: boolean
 }
-
-export const displayPerimeterZoomMaxLevel = 7
 
 export const CaminoMap = caminoDefineComponent<Props>(['markerLayers', 'geojsonLayers', 'mapUpdate', 'additionalOverlayLayers', 'loading'], (props, { expose }) => {
   const map = ref<HTMLDivElement | null>(null)

--- a/packages/ui/src/components/_map/leaflet.ts
+++ b/packages/ui/src/components/_map/leaflet.ts
@@ -1,4 +1,4 @@
-import type { LatLngExpression, Icon, DivIcon, GeoJSONOptions, DivIconOptions, IconOptions } from 'leaflet'
+import type { LatLngExpression, Icon, DivIcon, GeoJSONOptions, DivIconOptions } from 'leaflet'
 import { GeoJsonObject } from 'geojson'
 import 'leaflet.markercluster'
 import 'leaflet-gesture-handling'

--- a/packages/ui/src/components/_map/util.ts
+++ b/packages/ui/src/components/_map/util.ts
@@ -1,0 +1,2 @@
+// Il n'est pas dans index.tsx afin de pouvoir charger de manière asynchrone les composants qui contiennent du leaflet
+export const displayPerimeterZoomMaxLevel = 7

--- a/packages/ui/src/components/titres.tsx
+++ b/packages/ui/src/components/titres.tsx
@@ -1,11 +1,11 @@
-import { defineComponent, computed, onMounted, inject, FunctionalComponent, ref } from 'vue'
+import { defineComponent, defineAsyncComponent, computed, onMounted, inject, FunctionalComponent, ref } from 'vue'
 import { Icon } from '@/components/_ui/icon'
 import { TitresTypesIds } from 'camino-common/src/static/titresTypes'
 import { canCreateTitre } from 'camino-common/src/permissions/titres'
 import { useStore } from 'vuex'
 import { User } from 'camino-common/src/roles'
 import { TitreFiltresParams, TitresFiltres, getInitialTitresFiltresParams } from './titres/filtres'
-import { CaminoTitresMap, TitreCarteParams } from './titres/map'
+import type { TitreCarteParams } from './titres/map'
 import { Navigation } from './_ui/navigation'
 import { Tab, newTabId, Tabs, TabId } from './_ui/tabs'
 import { PageContentHeader } from './_common/page-header-content'
@@ -14,8 +14,8 @@ import { AsyncData } from '@/api/client-rest'
 import { LocationQuery, useRouter } from 'vue-router'
 import { routerQueryToString } from '@/router/camino-router-link'
 import { titresColonnes, titresLignesBuild } from './titres/table-utils'
-import { TitreWithPoint } from './titres/mapUtil'
-import { displayPerimeterZoomMaxLevel } from './_map'
+import type { TitreWithPoint } from './titres/mapUtil'
+import { displayPerimeterZoomMaxLevel } from './_map/util'
 import { apiClient } from '../api/api-client'
 import { TablePagination, getInitialParams } from './_ui/table-pagination'
 import { canReadActivites } from 'camino-common/src/permissions/activites'
@@ -46,6 +46,10 @@ const tableTabId = newTabId('table')
 type TitresTablePaginationParams = { page: number; colonne: (typeof titresColonnes)[number]['id']; ordre: 'asc' | 'desc' }
 export const Titres = defineComponent({
   setup() {
+    const CaminoTitresMap = defineAsyncComponent(async () => {
+      const { CaminoTitresMap } = await import('./titres/map')
+      return CaminoTitresMap
+    })
     const matomo = inject('matomo', null)
     const store = useStore()
     const router = useRouter()

--- a/packages/ui/src/components/titres/mapUtil.ts
+++ b/packages/ui/src/components/titres/mapUtil.ts
@@ -1,7 +1,7 @@
 import { leafletGeojsonCenterFind, leafletGeojsonBuild, leafletMarkerBuild, leafletDivIconBuild } from '../_map/leaflet'
 import { getDomaineId, getTitreTypeType } from 'camino-common/src/static/titresTypes'
 import { DomaineId, sortedDomaines } from 'camino-common/src/static/domaines'
-import { DivIconOptions, GeoJSON, GeoJSONOptions, Layer, LeafletEventHandlerFnMap, Map, Marker, MarkerClusterGroup, PopupOptions } from 'leaflet'
+import type { DivIconOptions, GeoJSON, GeoJSONOptions, Layer, LeafletEventHandlerFnMap, Marker, MarkerClusterGroup, PopupOptions } from 'leaflet'
 import { Router } from 'vue-router'
 import { CommonTitre, TitreId } from 'camino-common/src/titres'
 import { GeoJsonObject } from 'geojson'


### PR DESCRIPTION
## Checklist

* [ ] La carte s'affiche correctement sur la page "Titres et Autorisations"
* [ ] La carte s'affiche correctement sur la page de visualisation d'un titre
* [ ] La carte s'affiche correctement sur la page de visualisation d'une étape avec périmètre

## Tech

Avant : 
![2023-09-13_10-36-40_grim](https://github.com/MTES-MCT/camino/assets/414642/1326e34c-54c2-4751-85f1-28e6246aa0c2)
Après :
![2023-09-13_10-36-16_grim](https://github.com/MTES-MCT/camino/assets/414642/34e89507-3971-4cea-acd5-981d26b3d26e)


On passe d'un index.js à 1,587.35 kB vers 1,364.02 kB

Toute la partie leaflet se retrouve dans le fichier mapUtil-hash.js