### PR TITLE
fix(ui): améliore le glisser déposer et corrige la carte d’une étape

### DIFF
--- a/packages/ui/src/components/_common/perimetre.tsx
+++ b/packages/ui/src/components/_common/perimetre.tsx
@@ -1,6 +1,6 @@
 import { Point } from '@/utils/titre-etape-edit'
 import { TitreTypeId } from 'camino-common/src/static/titresTypes'
-import { FunctionalComponent, defineAsyncComponent, defineComponent } from 'vue'
+import { defineAsyncComponent, defineComponent, computed } from 'vue'
 import { Icon } from '../_ui/icon'
 import { Icon as IconSprite } from '../_ui/iconSpriteType'
 import type { Props as CaminoCommonMapProps } from './map'
@@ -29,7 +29,7 @@ const tabs: { id: TabId; nom: Capitalize<TabId>; icon: IconSprite }[] = [
 
 export const Perimetre = defineComponent<Props>((props: Props) => {
   const isMain = props.isMain ?? false
-  const tabId = props.tabId ?? 'carte'
+  const tabId = computed(() => props.tabId ?? 'carte')
   const titreId = props.titreId ?? ''
   const CaminoCommonMap = defineAsyncComponent(async () => {
     const { CaminoCommonMap } = await import('./map')
@@ -62,8 +62,8 @@ export const Perimetre = defineComponent<Props>((props: Props) => {
         <div class="tablet-blob-1-2 flex">
           {tabs.map(tab => {
             return (
-              <div key={tab.id} class={`${tabId === tab.id ? 'active' : ''} mr-xs`}>
-                {tabId !== tab.id ? (
+              <div key={tab.id} class={`${tabId.value === tab.id ? 'active' : ''} mr-xs`}>
+                {tabId.value !== tab.id ? (
                   <ButtonIcon class="p-m btn-tab rnd-t-s" onClick={() => props.tabUpdate(tab.id)} title={`Affiche le périmètre (${tab.nom})`} icon={tab.icon} />
                 ) : (
                   <div class="p-m span-tab rnd-t-s">
@@ -78,7 +78,7 @@ export const Perimetre = defineComponent<Props>((props: Props) => {
 
       <div class={`${isMain ? 'width-full' : ''} line-neutral`} />
 
-      {props.points && props.geojsonMultiPolygon && tabId === 'carte' ? (
+      {props.points && props.geojsonMultiPolygon && tabId.value === 'carte' ? (
         <CaminoCommonMap
           class={`${isMain ? 'width-full' : ''} dsfr`}
           geojson={props.geojsonMultiPolygon}
@@ -90,7 +90,7 @@ export const Perimetre = defineComponent<Props>((props: Props) => {
         />
       ) : null}
 
-      {props.points && tabId === 'points' ? (
+      {props.points && tabId.value === 'points' ? (
         <div class={`${isMain ? 'width-full' : ''} points bg-alt`}>
           <div class={`${isMain ? 'container' : ''} bg-bg py`}>
             <Points points={props.points} />

--- a/packages/ui/src/components/_ui/dsfr-input-file.tsx
+++ b/packages/ui/src/components/_ui/dsfr-input-file.tsx
@@ -1,12 +1,18 @@
 import { caminoDefineComponent, isEventWithTarget } from '@/utils/vue-tsx-utils'
 import { FileUploadType } from 'camino-common/src/static/documentsTypes'
+import { ref } from 'vue'
 
 interface Props {
   accept: FileUploadType[]
   uploadFile: (file: File) => void
 }
 
+const isDragEvent = (e: Event): e is DragEvent => {
+  return 'dataTransfer' in e
+}
+
 export const InputFile = caminoDefineComponent<Props>(['accept', 'uploadFile'], props => {
+  const inputValue = ref<FileList | null>(null)
   const uploadFile = (e: Event) => {
     if (isEventWithTarget(e)) {
       const file = e.target.files?.item(0)
@@ -16,14 +22,38 @@ export const InputFile = caminoDefineComponent<Props>(['accept', 'uploadFile'], 
     }
   }
 
+  const dropFile = (e: Event) => {
+    dragHover.value = false
+    e.preventDefault()
+    e.stopPropagation()
+    if (isDragEvent(e)) {
+      const file = e.dataTransfer?.files?.item(0)
+      inputValue.value = e.dataTransfer?.files ?? null
+      if (file) {
+        props.uploadFile(file)
+      }
+    }
+  }
+
+  const dragHover = ref(false)
+
+  const onDragHover = (e: Event) => {
+    dragHover.value = true
+    e.preventDefault()
+    e.stopPropagation()
+  }
+  const onDragLeave = (e: Event) => {
+    dragHover.value = false
+  }
   return () => (
     <div class="dsfr">
-      <div class="fr-upload-group">
+      <div class="fr-upload-group" style={{ opacity: dragHover.value ? '20%' : '100%' }} onDragover={onDragHover} onDragleave={onDragLeave} onDrop={dropFile}>
         <label class="fr-label" for="file-upload">
           Ajouter un fichier
           <span class="fr-hint-text">Taille maximale : 30 Mo. Formats supportés : {props.accept.join(', ')}.</span>
         </label>
-        <input class="fr-upload" type="file" id="file-upload" name="file-upload" accept={props.accept.map(a => `.${a}`).join(',')} onChange={uploadFile} />
+        {/* @ts-ignore files n'est pas reconnu par le typage... */}
+        <input files={inputValue.value} class="fr-upload" type="file" id="file-upload" name="file-upload" accept={props.accept.map(a => `.${a}`).join(',')} onChange={uploadFile} />
       </div>
     </div>
   )


### PR DESCRIPTION
- [ ] Le glisser déposer d’un fichier est plus joli et fonctionne toujours
- [ ] La carte affichée sur une étape refonctionne (https://preprod.camino.beta.gouv.fr/etapes/s-cx-donges-2001-oct01-dpu01/)