### PR TITLE
fix(scroll): Scroll automatiquement en haut des pages suivantes et conserve le scroll lors des retours

### DIFF
--- a/packages/ui/src/router/index.ts
+++ b/packages/ui/src/router/index.ts
@@ -449,6 +449,13 @@ const router = createRouter({
   history,
   linkActiveClass: 'active',
   linkExactActiveClass: 'exact-active',
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    } else {
+      return { top: 0 }
+    }
+  },
 })
 
 router.isReady().then(async () => {})


### PR DESCRIPTION
 - [ ] Quand on clique sur un lien, le scroll est tout en haut de la nouvelle page
 - [ ] Quand on revient en arrière, le scroll retrouve sa position d’origine