### PR TITLE
chore(api): ajoute des warning quand on a pas des expressions booléenes strictes

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -127,6 +127,9 @@
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "project": true
+    },
     "extends": [
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
@@ -204,7 +207,8 @@
           "argsIgnorePattern": "^_",
           "varsIgnorePattern": "^_"
         }
-      ]
+      ],
+      "@typescript-eslint/strict-boolean-expressions": "warn"
     }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -93,6 +93,7 @@
   },
   "eslintConfig": {
     "root": true,
+
     "env": {
       "node": true
     },


### PR DESCRIPTION
À voir pourquoi l'ui n'aime pas cette config
