### PR TITLE
fix(tableau): remplace le lien désactivé par un label dans l’entête des tableaux

### DIFF
--- a/packages/ui/src/components/_ui/table-auto.tsx
+++ b/packages/ui/src/components/_ui/table-auto.tsx
@@ -78,9 +78,7 @@ export const TableAuto = caminoDefineComponent<Props>(['caption', 'rows', 'colum
               {props.columns.map(col => (
                 <th key={col.id} scope="col" class={[...(col.class ?? []), 'nowrap']}>
                   {col.noSort ? (
-                    <a class={['fr-link']} title={col.name} aria-label={col.name}>
-                      {col.name === '' ? '-' : col.name}
-                    </a>
+                    <div class="fr-text--md">{col.name === '' ? '-' : col.name}</div>
                   ) : sort.column === col.id ? (
                     <a
                       class={['fr-link', 'fr-link--icon-right', sort.order === 'asc' ? 'fr-icon-arrow-down-fill' : 'fr-icon-arrow-up-fill']}

--- a/packages/ui/src/components/_ui/table.tsx
+++ b/packages/ui/src/components/_ui/table.tsx
@@ -106,9 +106,7 @@ export const Table = defineComponent(
                 {props.columns.map(col => (
                   <th key={col.id} scope="col" class="nowrap">
                     {col.noSort ? (
-                      <CaminoRouterLink class={['fr-link']} isDisabled={true} title={col.name} to="">
-                        {col.name === '' ? '-' : col.name}
-                      </CaminoRouterLink>
+                      <div class="fr-text--md">{col.name === '' ? '-' : col.name}</div>
                     ) : sortParams.value.column === col.id ? (
                       <CaminoRouterLink
                         class={['fr-link', 'fr-link--icon-right', sortParams.value.order === 'asc' ? 'fr-icon-arrow-down-fill' : 'fr-icon-arrow-up-fill']}

--- a/packages/ui/src/components/activite.stories_snapshots_ACompleter.html
+++ b/packages/ui/src/components/activite.stories_snapshots_ACompleter.html
@@ -57,8 +57,12 @@
                       <caption>Documents de l’activité</caption>
                       <thead>
                         <tr>
-                          <th scope="col" class="nowrap"><a class="fr-link" title="Nom" aria-label="Nom">Nom</a></th>
-                          <th scope="col" class="nowrap"><a class="fr-link" title="Description" aria-label="Description">Description</a></th>
+                          <th scope="col" class="nowrap">
+                            <div class="fr-text--md">Nom</div>
+                          </th>
+                          <th scope="col" class="nowrap">
+                            <div class="fr-text--md">Description</div>
+                          </th>
                         </tr>
                       </thead>
                       <tbody>

--- a/packages/ui/src/components/activite.stories_snapshots_Deposable.html
+++ b/packages/ui/src/components/activite.stories_snapshots_Deposable.html
@@ -56,8 +56,12 @@
                       <caption>Documents de l’activité</caption>
                       <thead>
                         <tr>
-                          <th scope="col" class="nowrap"><a class="fr-link" title="Nom" aria-label="Nom">Nom</a></th>
-                          <th scope="col" class="nowrap"><a class="fr-link" title="Description" aria-label="Description">Description</a></th>
+                          <th scope="col" class="nowrap">
+                            <div class="fr-text--md">Nom</div>
+                          </th>
+                          <th scope="col" class="nowrap">
+                            <div class="fr-text--md">Description</div>
+                          </th>
                         </tr>
                       </thead>
                       <tbody>

--- a/packages/ui/src/components/activite.stories_snapshots_Supprimable.html
+++ b/packages/ui/src/components/activite.stories_snapshots_Supprimable.html
@@ -58,8 +58,12 @@
                       <caption>Documents de l’activité</caption>
                       <thead>
                         <tr>
-                          <th scope="col" class="nowrap"><a class="fr-link" title="Nom" aria-label="Nom">Nom</a></th>
-                          <th scope="col" class="nowrap"><a class="fr-link" title="Description" aria-label="Description">Description</a></th>
+                          <th scope="col" class="nowrap">
+                            <div class="fr-text--md">Nom</div>
+                          </th>
+                          <th scope="col" class="nowrap">
+                            <div class="fr-text--md">Description</div>
+                          </th>
                         </tr>
                       </thead>
                       <tbody>

--- a/packages/ui/src/components/administration.stories_snapshots_Default.html
+++ b/packages/ui/src/components/administration.stories_snapshots_Default.html
@@ -69,7 +69,9 @@
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Prénom" aria-label="Trier par la colonne Prénom" href="#!">Prénom</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Email" aria-label="Trier par la colonne Email" href="#!">Email</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Rôle" aria-label="Trier par la colonne Rôle" href="#!">Rôle</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Lien" aria-label="Lien">Lien</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Lien</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/dashboard/pure-administration-dashboard.stories_snapshots_Ok.html
+++ b/packages/ui/src/components/dashboard/pure-administration-dashboard.stories_snapshots_Ok.html
@@ -48,7 +48,9 @@
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Nom" aria-label="Trier par la colonne Nom" href="#!">Nom</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Statut" aria-label="Trier par la colonne Statut" href="#!">Statut</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Dernière étape" aria-label="Trier par la colonne Dernière étape" href="#!">Dernière étape</a></th>
             </tr>

--- a/packages/ui/src/components/dashboard/pure-administration-dashboard.stories_snapshots_OkWithoutBlockedTitres.html
+++ b/packages/ui/src/components/dashboard/pure-administration-dashboard.stories_snapshots_OkWithoutBlockedTitres.html
@@ -20,7 +20,9 @@
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Nom" aria-label="Trier par la colonne Nom" href="#!">Nom</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Statut" aria-label="Trier par la colonne Statut" href="#!">Statut</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Dernière étape" aria-label="Trier par la colonne Dernière étape" href="#!">Dernière étape</a></th>
             </tr>

--- a/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_Ok.html
+++ b/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_Ok.html
@@ -18,12 +18,22 @@
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne " aria-label="Trier par la colonne " href="#!">-</a></th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
             <th scope="col" class="nowrap"><a class="fr-link fr-link--icon-right fr-icon-arrow-down-fill" title="Trier par la colonne Statut par ordre descendant" aria-label="Trier par la colonne Statut par ordre descendant" href="#!">Statut</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Activités" aria-label="Activités">Activités</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Substances" aria-label="Substances">Substances</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Activités</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Substances</div>
+            </th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Régions" aria-label="Régions">Régions</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Départements" aria-label="Départements">Départements</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Régions</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Départements</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Références</div>
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_OkWithMultipleEntreprises.html
+++ b/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_OkWithMultipleEntreprises.html
@@ -18,12 +18,22 @@
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne " aria-label="Trier par la colonne " href="#!">-</a></th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
             <th scope="col" class="nowrap"><a class="fr-link fr-link--icon-right fr-icon-arrow-down-fill" title="Trier par la colonne Statut par ordre descendant" aria-label="Trier par la colonne Statut par ordre descendant" href="#!">Statut</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Activités" aria-label="Activités">Activités</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Substances" aria-label="Substances">Substances</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Activités</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Substances</div>
+            </th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Régions" aria-label="Régions">Régions</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Départements" aria-label="Départements">Départements</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Régions</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Départements</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Références</div>
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_OkWithoutActivities.html
+++ b/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_OkWithoutActivities.html
@@ -18,11 +18,19 @@
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne " aria-label="Trier par la colonne " href="#!">-</a></th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
             <th scope="col" class="nowrap"><a class="fr-link fr-link--icon-right fr-icon-arrow-down-fill" title="Trier par la colonne Statut par ordre descendant" aria-label="Trier par la colonne Statut par ordre descendant" href="#!">Statut</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Substances" aria-label="Substances">Substances</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Substances</div>
+            </th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Régions" aria-label="Régions">Régions</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Départements" aria-label="Départements">Départements</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Régions</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Départements</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Références</div>
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_OkWithoutFiscalite.html
+++ b/packages/ui/src/components/dashboard/pure-entreprise-dashboard.stories_snapshots_OkWithoutFiscalite.html
@@ -18,12 +18,22 @@
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne " aria-label="Trier par la colonne " href="#!">-</a></th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
             <th scope="col" class="nowrap"><a class="fr-link fr-link--icon-right fr-icon-arrow-down-fill" title="Trier par la colonne Statut par ordre descendant" aria-label="Trier par la colonne Statut par ordre descendant" href="#!">Statut</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Activités" aria-label="Activités">Activités</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Substances" aria-label="Substances">Substances</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Activités</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Substances</div>
+            </th>
             <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Régions" aria-label="Régions">Régions</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Départements" aria-label="Départements">Départements</a></th>
-            <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Régions</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Départements</div>
+            </th>
+            <th scope="col" class="nowrap">
+              <div class="fr-text--md">Références</div>
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/packages/ui/src/components/dashboard/pure-onf-dashboard.stories_snapshots_Ok.html
+++ b/packages/ui/src/components/dashboard/pure-onf-dashboard.stories_snapshots_Ok.html
@@ -15,7 +15,9 @@
             <tr>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Nom" aria-label="Trier par la colonne Nom" href="#!">Nom</a></th>
               <th scope="col" class="nowrap"><a class="fr-link fr-link--icon-right fr-icon-arrow-down-fill" title="Trier par la colonne Statut par ordre descendant" aria-label="Trier par la colonne Statut par ordre descendant" href="#!">Statut</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Date complétude PTMG" aria-label="Trier par la colonne Date complétude PTMG" href="#!">Date complétude PTMG</a></th>
             </tr>
@@ -67,7 +69,9 @@
             <tr>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Nom" aria-label="Trier par la colonne Nom" href="#!">Nom</a></th>
               <th scope="col" class="nowrap"><a class="fr-link fr-link--icon-right fr-icon-arrow-down-fill" title="Trier par la colonne Statut par ordre descendant" aria-label="Trier par la colonne Statut par ordre descendant" href="#!">Statut</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Date complétude PTMG" aria-label="Trier par la colonne Date complétude PTMG" href="#!">Date complétude PTMG</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Date réception ONF" aria-label="Trier par la colonne Date réception ONF" href="#!">Date réception ONF</a></th>

--- a/packages/ui/src/components/dashboard/pure-onf-dashboard.stories_snapshots_OkSansAttenteDeONF.html
+++ b/packages/ui/src/components/dashboard/pure-onf-dashboard.stories_snapshots_OkSansAttenteDeONF.html
@@ -16,7 +16,9 @@
             <tr>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Nom" aria-label="Trier par la colonne Nom" href="#!">Nom</a></th>
               <th scope="col" class="nowrap"><a class="fr-link fr-link--icon-right fr-icon-arrow-down-fill" title="Trier par la colonne Statut par ordre descendant" aria-label="Trier par la colonne Statut par ordre descendant" href="#!">Statut</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Date complétude PTMG" aria-label="Trier par la colonne Date complétude PTMG" href="#!">Date complétude PTMG</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Date réception ONF" aria-label="Trier par la colonne Date réception ONF" href="#!">Date réception ONF</a></th>

--- a/packages/ui/src/components/demarches/page.stories_snapshots_Demarches.html
+++ b/packages/ui/src/components/demarches/page.stories_snapshots_Demarches.html
@@ -288,7 +288,9 @@
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut de titre" class="fr-link" aria-label="Trier par la colonne Statut de titre">Statut de titre</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Type" class="fr-link" aria-label="Trier par la colonne Type">Type</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut" class="fr-link" aria-label="Trier par la colonne Statut">Statut</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Références" class="fr-link" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/demarches/page.stories_snapshots_Loading.html
+++ b/packages/ui/src/components/demarches/page.stories_snapshots_Loading.html
@@ -291,7 +291,9 @@
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut de titre" class="fr-link" aria-label="Trier par la colonne Statut de titre">Statut de titre</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Type" class="fr-link" aria-label="Trier par la colonne Type">Type</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut" class="fr-link" aria-label="Trier par la colonne Statut">Statut</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Références" class="fr-link" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/demarches/page.stories_snapshots_Travaux.html
+++ b/packages/ui/src/components/demarches/page.stories_snapshots_Travaux.html
@@ -271,7 +271,9 @@
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut de titre" class="fr-link" aria-label="Trier par la colonne Statut de titre">Statut de titre</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Type" class="fr-link" aria-label="Trier par la colonne Type">Type</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut" class="fr-link" aria-label="Trier par la colonne Statut">Statut</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Références" class="fr-link" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/demarches/page.stories_snapshots_WithError.html
+++ b/packages/ui/src/components/demarches/page.stories_snapshots_WithError.html
@@ -303,7 +303,9 @@
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut de titre" class="fr-link" aria-label="Trier par la colonne Statut de titre">Statut de titre</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Type" class="fr-link" aria-label="Trier par la colonne Type">Type</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Statut" class="fr-link" aria-label="Trier par la colonne Statut">Statut</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Références" class="fr-link" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/entreprise.stories_snapshots_Complet.html
+++ b/packages/ui/src/components/entreprise.stories_snapshots_Complet.html
@@ -153,7 +153,9 @@
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Prénom" aria-label="Trier par la colonne Prénom" href="#!">Prénom</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Email" aria-label="Trier par la colonne Email" href="#!">Email</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Rôle" aria-label="Trier par la colonne Rôle" href="#!">Rôle</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Lien" aria-label="Lien">Lien</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Lien</div>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -188,12 +190,22 @@
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne " aria-label="Trier par la colonne " href="#!">-</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Statut" aria-label="Trier par la colonne Statut" href="#!">Statut</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Activités" aria-label="Activités">Activités</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Substances" aria-label="Substances">Substances</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Activités</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Substances</div>
+              </th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Régions" aria-label="Régions">Régions</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Départements" aria-label="Départements">Départements</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Régions</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Départements</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -262,12 +274,22 @@
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne " aria-label="Trier par la colonne " href="#!">-</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Type" aria-label="Trier par la colonne Type" href="#!">Type</a></th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Statut" aria-label="Trier par la colonne Statut" href="#!">Statut</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Activités" aria-label="Activités">Activités</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Substances" aria-label="Substances">Substances</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Activités</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Substances</div>
+              </th>
               <th scope="col" class="nowrap"><a class="fr-link" title="Trier par la colonne Titulaires" aria-label="Trier par la colonne Titulaires" href="#!">Titulaires</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Régions" aria-label="Régions">Régions</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Départements" aria-label="Départements">Départements</a></th>
-              <th scope="col" class="nowrap"><a class="fr-link" title="Références" aria-label="Références">Références</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Régions</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Départements</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Références</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/journaux/journaux.stories_snapshots_AvecPagination.html
+++ b/packages/ui/src/components/journaux/journaux.stories_snapshots_AvecPagination.html
@@ -18,11 +18,21 @@
           <caption>Journaux</caption>
           <thead>
             <tr>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Date" class="fr-link" aria-label="Date">Date</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Titre" class="fr-link" aria-label="Titre">Titre</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Utilisateur" class="fr-link" aria-label="Utilisateur">Utilisateur</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Action" class="fr-link" aria-label="Action">Action</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Modifications" class="fr-link" aria-label="Modifications">Modifications</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Date</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Titre</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Utilisateur</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Action</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Modifications</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/journaux/journaux.stories_snapshots_Default.html
+++ b/packages/ui/src/components/journaux/journaux.stories_snapshots_Default.html
@@ -18,11 +18,21 @@
           <caption>Journaux</caption>
           <thead>
             <tr>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Date" class="fr-link" aria-label="Date">Date</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Titre" class="fr-link" aria-label="Titre">Titre</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Utilisateur" class="fr-link" aria-label="Utilisateur">Utilisateur</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Action" class="fr-link" aria-label="Action">Action</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Modifications" class="fr-link" aria-label="Modifications">Modifications</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Date</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Titre</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Utilisateur</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Action</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Modifications</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/journaux/journaux.stories_snapshots_Loading.html
+++ b/packages/ui/src/components/journaux/journaux.stories_snapshots_Loading.html
@@ -18,11 +18,21 @@
           <caption>Journaux</caption>
           <thead>
             <tr>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Date" class="fr-link" aria-label="Date">Date</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Titre" class="fr-link" aria-label="Titre">Titre</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Utilisateur" class="fr-link" aria-label="Utilisateur">Utilisateur</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Action" class="fr-link" aria-label="Action">Action</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Modifications" class="fr-link" aria-label="Modifications">Modifications</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Date</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Titre</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Utilisateur</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Action</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Modifications</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/journaux/journaux.stories_snapshots_WithError.html
+++ b/packages/ui/src/components/journaux/journaux.stories_snapshots_WithError.html
@@ -18,11 +18,21 @@
           <caption>Journaux</caption>
           <thead>
             <tr>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Date" class="fr-link" aria-label="Date">Date</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Titre" class="fr-link" aria-label="Titre">Titre</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Utilisateur" class="fr-link" aria-label="Utilisateur">Utilisateur</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Action" class="fr-link" aria-label="Action">Action</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Modifications" class="fr-link" aria-label="Modifications">Modifications</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Date</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Titre</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Utilisateur</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Action</div>
+              </th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Modifications</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/metas.stories_snapshots_Super.html
+++ b/packages/ui/src/components/metas.stories_snapshots_Super.html
@@ -18,7 +18,9 @@
           <caption>métas</caption>
           <thead>
             <tr>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Nom" class="fr-link" aria-label="Nom">Nom</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Nom</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/utilisateurs.stories_snapshots_Connected.html
+++ b/packages/ui/src/components/utilisateurs.stories_snapshots_Connected.html
@@ -103,7 +103,9 @@
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Prénom" class="fr-link" aria-label="Trier par la colonne Prénom">Prénom</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Email" class="fr-link" aria-label="Trier par la colonne Email">Email</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Rôle" class="fr-link" aria-label="Trier par la colonne Rôle">Rôle</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Lien" class="fr-link" aria-label="Lien">Lien</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Lien</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/utilisateurs.stories_snapshots_Loading.html
+++ b/packages/ui/src/components/utilisateurs.stories_snapshots_Loading.html
@@ -103,7 +103,9 @@
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Prénom" class="fr-link" aria-label="Trier par la colonne Prénom">Prénom</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Email" class="fr-link" aria-label="Trier par la colonne Email">Email</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Rôle" class="fr-link" aria-label="Trier par la colonne Rôle">Rôle</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Lien" class="fr-link" aria-label="Lien">Lien</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Lien</div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/packages/ui/src/components/utilisateurs.stories_snapshots_WithError.html
+++ b/packages/ui/src/components/utilisateurs.stories_snapshots_WithError.html
@@ -118,7 +118,9 @@
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Prénom" class="fr-link" aria-label="Trier par la colonne Prénom">Prénom</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Email" class="fr-link" aria-label="Trier par la colonne Email">Email</a></th>
               <th scope="col" class="nowrap"><a href="/mocked-href" title="Trier par la colonne Rôle" class="fr-link" aria-label="Trier par la colonne Rôle">Rôle</a></th>
-              <th scope="col" class="nowrap"><a aria-disabled="true" role="link" title="Lien" class="fr-link" aria-label="Lien">Lien</a></th>
+              <th scope="col" class="nowrap">
+                <div class="fr-text--md">Lien</div>
+              </th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
- [ ] Le style des tableaux de l’application est plus lisible pour les colonnes où on ne peut pas trier
<img width="1376" alt="Capture d’écran 2023-10-11 à 09 30 12" src="https://github.com/MTES-MCT/camino/assets/6149841/c25f2220-582d-473f-8e6e-8da9883ab68b">
