### PR TITLE
fix(statistiques): les statistique de la DGTM n'utilisent plus les rapports en construction

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
     "db:dump": "rm -rf ./backups/* && pg_dump --host=localhost --username=postgres --clean --if-exists --format=d --no-owner --no-privileges --dbname=camino --file=./backups/",
     "db:export": "rm -rf sources && node --loader ts-node/esm/transpile-only src/scripts/database-to-json-export.ts",
     "db:import": "pg_restore --host=localhost --username=postgres --clean --if-exists --no-owner --no-privileges --dbname=camino ./backups",
-    "db:prod-fetch": "rm -rf ./backups/* && scp -r -P 212 $u@camino.beta.gouv.fr:/srv/backups/dump/* backups/",
+    "db:prod-fetch": "rm -rf ./backups/* && scp -r $u@camino.beta.gouv.fr:/srv/backups/dump/* backups/",
     "db:recreate": "dropdb --host=localhost --username=postgres camino && createdb --host=localhost --username=postgres camino",
     "db:migrate": "node --loader ts-node/esm/transpile-only ./src/knex/migrate.ts",
     "db:add-migration": "NODE_OPTIONS='--loader ts-node/esm/transpile-only' knex migrate:make",

--- a/packages/api/src/api/rest/statistiques/dgtm.queries.ts
+++ b/packages/api/src/api/rest/statistiques/dgtm.queries.ts
@@ -19,6 +19,7 @@ from
 where
     ta.type_id in ('gra', 'grx')
     and (ta.contenu -> 'substancesFiscales' -> $ substance)::int > 0
+    and ta.activite_statut_id = 'dep'
     and ta.annee > 2017
 group by
     ta.annee


### PR DESCRIPTION
# Checklist

* [ ] Remplir une activité avec une production d'or non spécifiée (ne pas la déposer, juste l'enregistrer)
* [ ] Aller sur le dashboard de la DGTM, les statistiques doivent s'afficher

