### PR TITLE
fix(phases): prend en compte les publications qui annulent une publication antérieure

### DIFF
--- a/packages/api/src/business/rules/titre-phases-find.test.ts
+++ b/packages/api/src/business/rules/titre-phases-find.test.ts
@@ -1614,6 +1614,60 @@ describe("phases d'une démarche", () => {
     `)
   })
 
+  test('un titre qui a une publication au jorf rejetée puis une publication au jorf acceptée a une phase', () => {
+    expect(
+      titrePhasesFind(
+        [
+          {
+            titreId: newTitreId('titreId'),
+            statutId: 'acc',
+            ordre: 1,
+            typeId: 'oct',
+            id: newDemarcheId('demarcheIdOctroi'),
+            etapes: [
+              {
+                titreDemarcheId: newDemarcheId('demarcheIdOctroi'),
+                ordre: 3,
+                typeId: 'dpu',
+                dateFin: toCaminoDate('2033-11-23'),
+                dateDebut: toCaminoDate('2003-11-23'),
+                date: toCaminoDate('2003-11-23'),
+                statutId: 'acc',
+                points: [],
+              },
+              {
+                titreDemarcheId: newDemarcheId('demarcheIdOctroi'),
+                ordre: 2,
+                typeId: 'dpu',
+                dateFin: toCaminoDate('2033-11-22'),
+                dateDebut: toCaminoDate('2003-11-22'),
+                date: toCaminoDate('2003-11-22'),
+                statutId: 'rej',
+                points: [],
+              },
+              {
+                titreDemarcheId: newDemarcheId('demarcheIdOctroi'),
+                ordre: 1,
+                typeId: 'dex',
+                date: toCaminoDate('2003-04-26'),
+                statutId: 'acc',
+                points: [],
+              },
+            ],
+          },
+        ],
+        'prm'
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "demarcheIdOctroi": {
+          "dateDebut": "2003-11-23",
+          "dateFin": "2033-11-23",
+        },
+      }
+    `)
+  })
+
   test('cas réels', () => {
     const phasesReels = titresProd as TitrePhasesTest[]
     phasesReels.forEach(([titreTypeId, demarches], index) => {

--- a/packages/api/src/business/rules/titre-phases-find.ts
+++ b/packages/api/src/business/rules/titre-phases-find.ts
@@ -34,8 +34,10 @@ const findDateDebut = (demarche: TitreDemarchePhaseFind, titreTypeId: TitreTypeI
   // on trie les étapes de façon ascendante pour le cas où
   // il existe une étape de publication et une étape rectificative,
   // on prend alors en compte l'originale
-  const etapePublicationFirst = titreEtapesSortAscByOrdre(demarche.etapes).find(etape => titreEtapePublicationCheck(etape.typeId, titreTypeId))
-  if (etapePublicationFirst && [ETAPES_STATUTS.ACCEPTE, ETAPES_STATUTS.FAIT].includes(etapePublicationFirst.statutId)) {
+  const etapePublicationFirst = titreEtapesSortAscByOrdre(demarche.etapes).find(
+    etape => titreEtapePublicationCheck(etape.typeId, titreTypeId) && [ETAPES_STATUTS.ACCEPTE, ETAPES_STATUTS.FAIT].includes(etape.statutId)
+  )
+  if (etapePublicationFirst) {
     // retourne l’étape de publication la plus récente avec une date de début spécifiée
     const etapePublicationHasDateDebut = titreEtapesSortDescByOrdre(demarche.etapes).find(titreEtape => titreEtapePublicationCheck(titreEtape.typeId, titreTypeId) && titreEtape.dateDebut)
 


### PR DESCRIPTION
- [ ] Vérifier que les phases soient correctes sur le titre https://preprod.camino.beta.gouv.fr/titres/m-ax-crique-likanaon-2009 (à comparer avec la prod)
