### PR TITLE
chore(territoires): ajoute les façades maritimes au calcul des régions/pays pour savoir si il y'a des activités pour un titre

### DIFF
--- a/packages/api/src/api/rest/titres.queries.ts
+++ b/packages/api/src/api/rest/titres.queries.ts
@@ -223,7 +223,7 @@ export const getTitre = async (pool: Pool, user: User, idOrSlug: TitreIdOrSlug):
     let nb_activites_to_do: number | null = null
 
     if (
-      canHaveActivites({ titreTypeId: titre.titre_type_id, communes: perimetre?.communes ?? [], demarches: formattedDemarches }) &&
+      canHaveActivites({ titreTypeId: titre.titre_type_id, communes: perimetre?.communes ?? [], demarches: formattedDemarches, secteursMaritime: perimetre?.secteurs_maritimes ?? [] }) &&
       (await canReadTitreActivites(user, titreTypeId, administrationsLocales, entreprisesTitulairesOuAmodiataires))
     ) {
       nb_activites_to_do = titre.nb_activites_to_do

--- a/packages/api/src/business/processes/titres-activites-update.test.ts
+++ b/packages/api/src/business/processes/titres-activites-update.test.ts
@@ -59,6 +59,7 @@ const titresToutesActivites = [
     ],
     communes: [],
     demarches: [],
+    secteursMaritime: [],
   },
 ] as unknown as Titres[]
 
@@ -81,6 +82,7 @@ describe("activités d'un titre", () => {
       titulaires: [{ utilisateurs: [{ email: 'email' }] }],
       communes: [],
       demarches: [],
+      secteursMaritime: [],
     },
   ] as unknown as Titres[]
 

--- a/packages/api/src/business/processes/titres-activites-update.ts
+++ b/packages/api/src/business/processes/titres-activites-update.ts
@@ -46,8 +46,12 @@ export const titresActivitesUpdate = async (titresIds?: string[], aujourdhui: Ca
           throw new Error('les communes du titre ne sont pas chargées')
         }
 
+        if (isNullOrUndefined(titre.secteursMaritime)) {
+          throw new Error('les secteursMaritime du titre ne sont pas chargés')
+        }
+
         // si le type d'activité est relié au type de titre
-        if (!canHaveActiviteTypeId(activiteType.id, { titreTypeId: titre.typeId, communes: titre.communes, demarches: titre.demarches })) return acc
+        if (!canHaveActiviteTypeId(activiteType.id, { titreTypeId: titre.typeId, communes: titre.communes, secteursMaritime: titre.secteursMaritime, demarches: titre.demarches })) return acc
 
         acc.push(...titreActivitesBuild(activiteType.id, annees, aujourdhui, titre.id, titre.typeId, titre.demarches, titre.activites))
 

--- a/packages/common/src/permissions/titres.test.ts
+++ b/packages/common/src/permissions/titres.test.ts
@@ -157,6 +157,7 @@ describe('canHaveActivites', () => {
           titreTypeId: 'axm',
           demarches: [{}],
           communes: [],
+          secteursMaritime: [],
         })
       ).toEqual(false)
     })
@@ -167,13 +168,19 @@ describe('canHaveActivites', () => {
           titreTypeId: 'axm',
           demarches: [{}],
           communes: [{ id: toCommuneId('97300') }],
+          secteursMaritime: [],
         })
       ).toEqual(true)
     })
 
     test("ne retourne aucun type d'activité sur un titre AXM de métropole", () => {
       expect(
-        canHaveActiviteTypeId(ACTIVITES_TYPES_IDS["rapport trimestriel d'exploitation d'or en Guyane"], { titreTypeId: 'axm', demarches: [{}], communes: [{ id: toCommuneId('72000') }] })
+        canHaveActiviteTypeId(ACTIVITES_TYPES_IDS["rapport trimestriel d'exploitation d'or en Guyane"], {
+          titreTypeId: 'axm',
+          demarches: [{}],
+          communes: [{ id: toCommuneId('72000') }],
+          secteursMaritime: [],
+        })
       ).toEqual(false)
     })
 
@@ -183,6 +190,7 @@ describe('canHaveActivites', () => {
           titreTypeId: 'prm',
           demarches: [{}],
           communes: [{ id: toCommuneId('72000') }],
+          secteursMaritime: [],
         })
       ).toEqual(true)
     })
@@ -193,6 +201,7 @@ describe('canHaveActivites', () => {
           titreTypeId: 'prm',
           demarches: [{}],
           communes: [{ id: toCommuneId('72000') }],
+          secteursMaritime: [],
         })
       ).toEqual(false)
     })
@@ -203,6 +212,7 @@ describe('canHaveActivites', () => {
           titreTypeId: 'pxw',
           demarches: [{}],
           communes: [],
+          secteursMaritime: [],
         })
       ).toEqual(true)
     })
@@ -212,6 +222,7 @@ describe('canHaveActivites', () => {
           titreTypeId: 'pxw',
           demarches: [],
           communes: [],
+          secteursMaritime: [],
         })
       ).toEqual(false)
     })

--- a/packages/common/src/static/facades.ts
+++ b/packages/common/src/static/facades.ts
@@ -145,7 +145,7 @@ export const getFacadesComputed = (secteursMaritime: SecteursMaritimes[]): Facad
   }, [])
 }
 
-const getFacade = (secteurMaritime: SecteursMaritimes): FacadesMaritimes => {
+export const getFacade = (secteurMaritime: SecteursMaritimes): FacadesMaritimes => {
   const facade = getKeys(facades, isFacade).find(facade => Object.keys(facades[facade]).includes(secteurMaritime))
   assertsFacade(facade)
 

--- a/packages/common/src/territoires.test.ts
+++ b/packages/common/src/territoires.test.ts
@@ -1,6 +1,6 @@
 import { toCommuneId } from 'camino-common/src/static/communes.js'
 import { describe, expect, test } from 'vitest'
-import { territoiresFind } from './territoires'
+import { territoiresFind, territoiresIdFind } from './territoires'
 describe('territoiresFind', () => {
   test('territoiresFind uniquement des communes', () => {
     expect(
@@ -144,6 +144,99 @@ describe('territoiresFind', () => {
         "facades": [],
         "regions": [
           "Centre-Val de Loire",
+        ],
+      }
+    `)
+  })
+})
+
+describe('territoiresIdFind', () => {
+  test('territoiresIdFind communes et secteurs maritimes', () => {
+    expect(
+      territoiresIdFind(
+        [
+          { id: toCommuneId('72500') },
+          {
+            id: toCommuneId('72200'),
+          },
+
+          {
+            id: toCommuneId('37000'),
+          },
+        ],
+        ['Baie de Seine']
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "departements": [
+          "76",
+          "14",
+          "50",
+          "72",
+          "37",
+        ],
+        "facades": [
+          "Manche Est - Mer du Nord",
+        ],
+        "pays": [
+          "FR",
+        ],
+        "regions": [
+          "28",
+          "52",
+          "24",
+        ],
+      }
+    `)
+  })
+  test('territoiresIdFind uniquement des communes', () => {
+    expect(
+      territoiresIdFind(
+        [
+          { id: toCommuneId('72500') },
+          {
+            id: toCommuneId('72200'),
+          },
+
+          {
+            id: toCommuneId('37000'),
+          },
+        ],
+        []
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "departements": [
+          "72",
+          "37",
+        ],
+        "facades": [],
+        "pays": [
+          "FR",
+        ],
+        "regions": [
+          "52",
+          "24",
+        ],
+      }
+    `)
+  })
+  test('territoiresFind uniquement des secteurs maritimes', () => {
+    expect(territoiresIdFind([], ['Baie de Seine'])).toMatchInlineSnapshot(`
+      {
+        "departements": [
+          "76",
+          "14",
+          "50",
+        ],
+        "facades": [
+          "Manche Est - Mer du Nord",
+        ],
+        "pays": [
+          "FR",
+        ],
+        "regions": [
+          "28",
         ],
       }
     `)

--- a/packages/common/src/territoires.ts
+++ b/packages/common/src/territoires.ts
@@ -1,8 +1,9 @@
 import { CommuneId } from './static/communes.js'
-import { FacadeComputed, getDepartementsBySecteurs, getFacadesComputed, SecteursMaritimes } from './static/facades.js'
-import { DepartementLabel, Departements, toDepartementId } from './static/departement.js'
-import { RegionLabel, Regions } from './static/region.js'
+import { FacadeComputed, FacadesMaritimes, getDepartementsBySecteurs, getFacade, getFacadesComputed, SecteursMaritimes } from './static/facades.js'
+import { DepartementId, DepartementLabel, Departements, toDepartementId } from './static/departement.js'
+import { RegionId, RegionLabel, Regions } from './static/region.js'
 import { onlyUnique } from './typescript-tools.js'
+import { PaysId } from './static/pays.js'
 
 export const territoiresFind = (
   communesWithName: Record<CommuneId, string>,
@@ -52,4 +53,19 @@ export const territoiresFind = (
   result.facades.sort()
 
   return result
+}
+
+export const territoiresIdFind = (
+  communes: { id: CommuneId }[],
+  secteursMaritime: SecteursMaritimes[]
+): { departements: DepartementId[]; regions: RegionId[]; facades: FacadesMaritimes[]; pays: PaysId[] } => {
+  const departements: DepartementId[] = [...getDepartementsBySecteurs(secteursMaritime), ...communes.map(({ id }) => toDepartementId(id))].filter(onlyUnique)
+  const regions = departements.map(id => Departements[id].regionId).filter(onlyUnique)
+
+  return {
+    departements,
+    regions,
+    pays: regions.map(id => Regions[id].paysId).filter(onlyUnique),
+    facades: secteursMaritime.map(getFacade).filter(onlyUnique),
+  }
 }

--- a/packages/ui/src/components/titre.tsx
+++ b/packages/ui/src/components/titre.tsx
@@ -37,6 +37,7 @@ import { getAdministrationsLocales } from 'camino-common/src/administrations'
 import { getGestionnairesByTitreTypeId } from 'camino-common/src/static/administrationsTitresTypes'
 import { DemarcheEditPopup } from './titre/demarche-edit-popup'
 import { PhaseWithAlterations, phaseWithAlterations } from './titre/phase'
+import { SecteursMaritimes } from 'camino-common/src/static/facades'
 
 const activitesSort: TableSortEvent = {
   colonne: activitesColonneIdAnnee,
@@ -161,7 +162,7 @@ export const PureTitre = defineComponent<Props>(props => {
         const titre = titreData.value.value
 
         showActivitesLink.value =
-          canHaveActivites({ titreTypeId: titreData.value.value.titre_type_id, communes: communes.value, demarches: titreData.value.value.demarches }) &&
+          canHaveActivites({ titreTypeId: titreData.value.value.titre_type_id, communes: communes.value, secteursMaritime: secteursMaritime.value, demarches: titreData.value.value.demarches }) &&
           (await canReadTitreActivites(
             props.user,
             () => Promise.resolve(titre.titre_type_id),
@@ -231,6 +232,14 @@ export const PureTitre = defineComponent<Props>(props => {
   const communes = computed<{ id: CommuneId }[]>(() => {
     if (perimetre.value !== null) {
       return perimetre.value.communes
+    }
+
+    return []
+  })
+
+  const secteursMaritime = computed<SecteursMaritimes[]>(() => {
+    if (perimetre.value !== null) {
+      return perimetre.value.secteurs_maritimes
     }
 
     return []


### PR DESCRIPTION
On a rajouté les façades maritimes lors du calcul des pays rattachés au titre pour savoir si des activités sont attachées au titre ou non.

Aucun impact sur le daily


