### PR TITLE
fix(carte): corrige les tuiles de Openstreetmap qui ne se chargent pas

### DIFF
--- a/packages/ui/src/components/demarche/demarche-map.tsx
+++ b/packages/ui/src/components/demarche/demarche-map.tsx
@@ -1,4 +1,4 @@
-import { FunctionalComponent, HTMLAttributes, defineComponent, onMounted, ref, Ref, computed, watch, onBeforeUnmount } from 'vue'
+import { FunctionalComponent, HTMLAttributes, defineComponent, onMounted, ref, Ref, computed, watch, onUnmounted } from 'vue'
 import { FullscreenControl, Map, NavigationControl, StyleSpecification, LayerSpecification, LngLatBounds, SourceSpecification, Popup, GeoJSONSource } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { z } from 'zod'
@@ -79,7 +79,7 @@ const overlayMapNames = {
 const layersSourceSpecifications: Record<LayerId, SourceSpecification> = {
   osm: {
     type: 'raster',
-    tiles: ['https://a.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', 'https://b.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', 'https://c.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png'],
+    tiles: ['/openstreetmapfr/osmfr/{z}/{x}/{y}.png'],
     attribution: '&copy; Openstreetmap France | &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     maxzoom: 19,
   },
@@ -452,8 +452,8 @@ export const DemarcheMap = defineComponent<Props>(props => {
     }
   })
 
-  onBeforeUnmount(() => {
-    map.value?.off('moveend', moveend)
+  onUnmounted(() => {
+    map.value?.remove()
   })
 
   const selectLayer = (layer: LayerId) => {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -58,6 +58,11 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
+      '/openstreetmapfr': {
+        target: 'https://a.tile.openstreetmap.fr',
+        rewrite: path => path.replace(/^\/openstreetmapfr/, ''),
+        changeOrigin: true,
+      },
       '/apiUrl': {
         target: process.env.API_URL,
         changeOrigin: true,

--- a/ui_nginx.conf
+++ b/ui_nginx.conf
@@ -1,3 +1,9 @@
+upstream osmfr {
+    server a.tile.openstreetmap.fr:443;
+    server b.tile.openstreetmap.fr:443;
+    server c.tile.openstreetmap.fr:443;
+}
+
 server {
     listen       ${UI_PORT};
     listen  [::]:${UI_PORT};
@@ -52,6 +58,10 @@ server {
         include /etc/nginx/conf.d/headers.conf;
         add_header Cache-Control "no-cache";
         proxy_pass   ${API_URL};
+    }
+
+    location /openstreetmapfr/ {
+        proxy_pass https://osmfr/;
     }
 
 }


### PR DESCRIPTION
see #845 

- On se tape des pbs de CORS qu’on a pas avec leaflet. Il y a que 2 diffs dans le call, je pense que c’est le header Origin qui n’est pas mis par leaflet contrairement à Maplibre. Impossible de modifier le call Maplibre pour virer le header
- J’ai mis un proxy pour passer via notre serveur pour éviter les CORS
- Ça marche parfaitement en local en passant par le proxy vite par contre en local via le nginx j’ai des tuiles ultras lentes qui ne se chargent pas
- Je suis pommé, je passe à autre chose. Va falloir peut-être changer de fond de carte par défaut…