### PR TITLE
chore(keycloak): n'affiche plus le message indiquant qu'un utilisateur existe déjà

### DIFF
--- a/infra/roles/camino/files/keycloak_theme/login/messages/messages_fr.properties
+++ b/infra/roles/camino/files/keycloak_theme/login/messages/messages_fr.properties
@@ -148,7 +148,7 @@ oauth2DeviceVerificationFailedMessage=Vous pouvez fermer cette fen\u00eatre de n
 oauth2DeviceConsentDeniedMessage=Consentement refus\u00e9 pour connecter l''appareil.
 oauth2DeviceAuthorizationGrantDisabledMessage=Le client n''est pas autoris\u00e9 \u00e0 initier OAuth 2.0 Device Authorization Grant. Le flux est d\u00e9sactiv\u00e9 pour ce client.
 
-emailVerifyInstruction1=Un courriel avec des instructions \u00e0 suivre vous a \u00e9t\u00e9 envoy\u00e9.
+emailVerifyInstruction1=Un courriel avec des instructions \u00e0 suivre vous a \u00e9t\u00e9 envoy\u00e9 \u00e0 l''adresse {0}.
 emailVerifyInstruction2=Vous n''avez pas re\u00e7u de code dans le courriel ?
 emailVerifyInstruction3=pour renvoyer le courriel.
 

--- a/infra/roles/camino/files/keycloak_theme/login/register.ftl
+++ b/infra/roles/camino/files/keycloak_theme/login/register.ftl
@@ -2,6 +2,15 @@
 <#import "register-commons.ftl" as registerCommons>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('firstName','lastName','email','password','password-confirm'); section>
     <#if section = "form">
+        <#if messagesPerField.existsError('email')>
+          <div class="fr-container">
+            <div class="fr-alert fr-alert--info fr-mt-3w">
+                <h3 class="fr-alert__title">${msg("emailVerifyInstruction1",(register.formData.email!''))}</h3>
+                <p>Si vous pensez avoir déjà créé votre compte sur Camino, utilisez la fonctionnalité "Mot de passe oublié"</p>
+            </div>
+          </div>
+        <#else>
+        
       <main class="fr-pt-md-14v" role="main" id="content">
     <div class="fr-container fr-container--fluid fr-mb-md-14v">
         <div class="fr-grid-row fr-grid-row-gutters fr-grid-row--center">
@@ -58,7 +67,7 @@
                                                     </div>
                                                 </div>
 
-                                                                                                
+
                                                 <div class="fr-fieldset__element">
                                                     <div class="fr-input-group <#if messagesPerField.existsError('email')>fr-input-group--error</#if>" aria-describedby="<#if messagesPerField.existsError('email')>text-input-email-error-desc-error</#if>">
                                                         <label class="fr-label" for="email">
@@ -136,5 +145,6 @@
         </div>
     </div>
 </main>
+      </#if>
     </#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
## Checklist

* [ ] Essayer de s'enregistrer avec son adresse email déjà présente sur camino
* [ ] Vérifier qu'on est bien rediriger vers une page "Un courriel avec des instructions..."


Pour Vincent --> On pourrait aller plus loin coté template et vérifier que l'erreur existe bien sur l'email et que c'est bien une erreur du type "email already exists", mais vu qu'on envoie les instructions par email, si la personne ne reçoit rien, elle reéssaiera je pense
