### PR TITLE
fix(perimetre): n'utilise plus ST_ReducePrecision qui, parfois, change les points de place

### DIFF
--- a/packages/api/src/api/rest/__snapshots__/perimetre.test.integration.ts.snap
+++ b/packages/api/src/api/rest/__snapshots__/perimetre.test.integration.ts.snap
@@ -8,6 +8,10 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
         [
           [
             [
+              -6508915.664,
+              4155227.249,
+            ],
+            [
               -6509838.38,
               4156321.503,
             ],
@@ -18,10 +22,6 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
             [
               -6508915.664,
               4155227.249,
-            ],
-            [
-              -6509838.38,
-              4156321.503,
             ],
           ],
         ],
@@ -37,6 +37,10 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
         [
           [
             [
+              329078.146,
+              466912.757,
+            ],
+            [
               327968.368,
               467101.879,
             ],
@@ -47,10 +51,6 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
             [
               329078.146,
               466912.757,
-            ],
-            [
-              327968.368,
-              467101.879,
             ],
           ],
         ],
@@ -66,6 +66,10 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
         [
           [
             [
+              -10635907.53,
+              28583935.69,
+            ],
+            [
               -10632537.838,
               28584100.036,
             ],
@@ -76,10 +80,6 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
             [
               -10635907.53,
               28583935.69,
-            ],
-            [
-              -10632537.838,
-              28584100.036,
             ],
           ],
         ],
@@ -124,6 +124,10 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
         [
           [
             [
+              995446.594,
+              468165.655,
+            ],
+            [
               994332.422,
               468346.681,
             ],
@@ -134,10 +138,6 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
             [
               995446.594,
               468165.655,
-            ],
-            [
-              994332.422,
-              468346.681,
             ],
           ],
         ],
@@ -153,6 +153,10 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
         [
           [
             [
+              -16143544.355,
+              26292802.746,
+            ],
+            [
               -16136616.095,
               26296480.296,
             ],
@@ -163,10 +167,6 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
             [
               -16143544.355,
               26292802.746,
-            ],
-            [
-              -16136616.095,
-              26296480.296,
             ],
           ],
         ],
@@ -182,6 +182,10 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
         [
           [
             [
+              1667272.177,
+              474656.113,
+            ],
+            [
               1666141.191,
               474830.764,
             ],
@@ -192,10 +196,6 @@ exports[`getGeojsonByGeoSystemeId > toutes les conversions 1`] = `
             [
               1667272.177,
               474656.113,
-            ],
-            [
-              1666141.191,
-              474830.764,
             ],
           ],
         ],

--- a/packages/api/src/api/rest/perimetre.queries.ts
+++ b/packages/api/src/api/rest/perimetre.queries.ts
@@ -17,9 +17,9 @@ import { isNullOrUndefined } from 'camino-common/src/typescript-tools.js'
 import { KM2, km2Validator, m2Validator } from 'camino-common/src/number.js'
 
 const precision = {
-  met: 0.001,
-  deg: 0.0001,
-  gon: 0.0001,
+  met: 3,
+  deg: 4,
+  gon: 4,
 } as const satisfies Record<GeoSysteme['uniteId'], number>
 
 export const getGeojsonByGeoSystemeId = async (
@@ -54,7 +54,7 @@ const getGeojsonByGeoSystemeIdDb = sql<
   Redefine<IGetGeojsonByGeoSystemeIdDbQuery, { fromGeoSystemeId: TransformableGeoSystemeId; toGeoSystemeId: TransformableGeoSystemeId; geojson: string; precision: number }, { geojson: MultiPolygon }>
 >`
 select
-    ST_AsGeoJSON (ST_Multi (ST_ReducePrecision (ST_Transform (ST_SetSRID (ST_GeomFromGeoJSON ($ geojson !::text), $ fromGeoSystemeId !::integer), $ toGeoSystemeId !::integer), $ precision !)))::json as geojson
+    ST_AsGeoJSON (ST_Multi (ST_Transform (ST_SetSRID (ST_GeomFromGeoJSON ($ geojson !::text), $ fromGeoSystemeId !::integer), $ toGeoSystemeId !::integer)), $ precision !)::json as geojson
 LIMIT 1
 `
 


### PR DESCRIPTION
Apparemment c'est une des fonctions postGIS qu'on utilisait qui change l'ordre des points...

J'ai crée un gros périmètre pour tester les coordonnées, attention, il n'aime pas trop être importé dans camino, il y'a toutes les communes de l'héxagone haha)

[test_conversion.zip](https://github.com/MTES-MCT/camino/files/14196636/test_conversion.zip)


Liée à la :
  * #755 

