### PR TITLE
chore(titres): optimise la requête qui calcule l’intersection

### DIFF
--- a/packages/api/src/database/queries/_titres-filters.ts
+++ b/packages/api/src/database/queries/_titres-filters.ts
@@ -61,7 +61,7 @@ export const titresFiltersQueryModify = (
 
   if (isNotNullNorUndefinedNorEmpty(perimetre) && perimetre.length === 4) {
     q.leftJoinRelated(jointureFormat(name, 'pointsEtape'))
-    q.whereRaw(`ST_INTERSECTS(??, st_setsrid('BOX(${perimetre[0]} ${perimetre[1]}, ${perimetre[2]} ${perimetre[3]})'::box2d, 4326)) is true`, ['pointsEtape.geojson4326_perimetre'])
+    q.whereRaw(`?? && ST_MakeEnvelope(${perimetre[0]}, ${perimetre[1]}, ${perimetre[2]}, ${perimetre[3]}, 4326) is true`, ['pointsEtape.geojson4326_perimetre'])
   }
 
   if (isNotNullNorUndefinedNorEmpty(domainesIds)) {


### PR DESCRIPTION
- [ ] On voit toujours les titres sur la page d’accueil