### PR TITLE
fix(statistiques): la page des granulats marins filtre correctement sur la page titres

### DIFF
--- a/packages/ui/src/components/statistiques/granulats-marins.stories_snapshots_Loading.html
+++ b/packages/ui/src/components/statistiques/granulats-marins.stories_snapshots_Loading.html
@@ -19,7 +19,7 @@
               <!---->
               <div class="_spinner_3306d0"></div>
             </div>
-            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ar,ap,pr,statutsIds:dmi,mod,vueId:table}}" type="primary">Voir les titres</a></p>
+            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ar,ap,pr,statutsIds:dmi,mod,sup,vueId:table}}" type="primary">Voir les titres</a></p>
           </div>
           <div class="tablet-blob-1-3">
             <p class="fr-display--xs _donnee-importante_65867c">
@@ -57,7 +57,7 @@
               <!---->
               <div class="_spinner_3306d0"></div>
             </div>
-            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ax,cx,px,statutsIds:dmi,mod,vueId:table}}" type="primary">Voir les titres</a></p>
+            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ax,cx,px,statutsIds:dmi,mod,sup,vueId:table}}" type="primary">Voir les titres</a></p>
           </div>
           <div class="tablet-blob-1-3">
             <p class="fr-display--xs _donnee-importante_65867c">

--- a/packages/ui/src/components/statistiques/granulats-marins.stories_snapshots_WithError.html
+++ b/packages/ui/src/components/statistiques/granulats-marins.stories_snapshots_WithError.html
@@ -31,7 +31,7 @@
               </div>
               <!---->
             </div>
-            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ar,ap,pr,statutsIds:dmi,mod,vueId:table}}" type="primary">Voir les titres</a></p>
+            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ar,ap,pr,statutsIds:dmi,mod,sup,vueId:table}}" type="primary">Voir les titres</a></p>
           </div>
           <div class="tablet-blob-1-3">
             <p class="fr-display--xs _donnee-importante_65867c">
@@ -93,7 +93,7 @@
               </div>
               <!---->
             </div>
-            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ax,cx,px,statutsIds:dmi,mod,vueId:table}}" type="primary">Voir les titres</a></p>
+            <p class="h6 text-center"><a to="{name:titres,query:{domainesIds:w,typesIds:ax,cx,px,statutsIds:dmi,mod,sup,vueId:table}}" type="primary">Voir les titres</a></p>
           </div>
           <div class="tablet-blob-1-3">
             <p class="fr-display--xs _donnee-importante_65867c">

--- a/packages/ui/src/components/statistiques/granulats-marins.tsx
+++ b/packages/ui/src/components/statistiques/granulats-marins.tsx
@@ -206,13 +206,13 @@ export const PureGranulatsMarins = caminoDefineComponent<Props>(['currentDate', 
                     if (item.raw.titresInstructionExploration > 1) {
                       return (
                         <div>
-                          <p class="bold text-center">Demandes en cours d'instruction (initiale et modification en instance)</p>
+                          <p class="bold text-center">Demandes en cours d'instruction (initiale, modification en instance et survie provisoire)</p>
                         </div>
                       )
                     } else {
                       return (
                         <div>
-                          <p class="bold text-center">Demande en cours d'instruction (initiale et modification en instance)</p>
+                          <p class="bold text-center">Demande en cours d'instruction (initiale, modification en instance et survie provisoire)</p>
                         </div>
                       )
                     }
@@ -225,7 +225,7 @@ export const PureGranulatsMarins = caminoDefineComponent<Props>(['currentDate', 
                       query: {
                         domainesIds: 'w',
                         typesIds: 'ar,ap,pr',
-                        statutsIds: 'dmi,mod',
+                        statutsIds: 'dmi,mod,sup',
                         vueId: 'table',
                       },
                     }}
@@ -277,13 +277,13 @@ export const PureGranulatsMarins = caminoDefineComponent<Props>(['currentDate', 
                     if (item.raw.titresInstructionExploitation > 1) {
                       return (
                         <div>
-                          <p class="bold text-center">Demandes en cours d'instruction (initiale et modification en instance)</p>
+                          <p class="bold text-center">Demandes en cours d'instruction (initiale, modification en instance et survie provisoire)</p>
                         </div>
                       )
                     } else {
                       return (
                         <div>
-                          <p class="bold text-center">Demande en cours d'instruction (initiale et modification en instance)</p>
+                          <p class="bold text-center">Demande en cours d'instruction (initiale, modification en instance et survie provisoire)</p>
                         </div>
                       )
                     }
@@ -297,7 +297,7 @@ export const PureGranulatsMarins = caminoDefineComponent<Props>(['currentDate', 
                       query: {
                         domainesIds: 'w',
                         typesIds: 'ax,cx,px',
-                        statutsIds: 'dmi,mod',
+                        statutsIds: 'dmi,mod,sup',
                         vueId: 'table',
                       },
                     }}
@@ -388,6 +388,7 @@ export const PureGranulatsMarins = caminoDefineComponent<Props>(['currentDate', 
                 enConstruction: id === anneeCurrent - 1, // l'année en cours n'étant pas affichée, seule l'année précédente est affichée à partir du 1er avril de l'année courante
               }
             })
+
             // TODO 2023-09-13 utiliser le dsfrSelect un fois la PR https://github.com/MTES-MCT/camino/pull/635 mergée
             return (
               <>


### PR DESCRIPTION
== Checklist

* [ ] Sur la page statistique des granulats marins, quand je clique sur 'voir les titres', je vois bien le même nombre de titres qu'annoncé (quand je suis connecté en super)
