### PR TITLE
refacto(dsfr): supprime le js des Tabs du DSFR

### DIFF
--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -3,7 +3,6 @@ import '../src/styles/styles.css'
 import '../src/styles/dsfr/dsfr.css'
 import '@gouvfr/dsfr/dist/core/core.module'
 import '@gouvfr/dsfr/dist/component/navigation/navigation.module'
-import '@gouvfr/dsfr/dist/component/tab/tab.module'
 
 import { setup } from '@storybook/vue3'
 import { h } from 'vue'

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -1,6 +1,5 @@
 import '@gouvfr/dsfr/dist/core/core.module'
 import '@gouvfr/dsfr/dist/component/navigation/navigation.module'
-import '@gouvfr/dsfr/dist/component/tab/tab.module'
 
 import { defineComponent, computed, ref, onMounted, inject } from 'vue'
 import { Header } from './components/page/header'

--- a/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPoints.html
+++ b/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPoints.html
@@ -298,12 +298,12 @@
   </defs>
 </svg>
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
       <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
       <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
     </ul>
-    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
       <!---->
     </div>
     <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPointsWithAnotherGeoSysteme.html
+++ b/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPointsWithAnotherGeoSysteme.html
@@ -298,12 +298,12 @@
   </defs>
 </svg>
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
       <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
       <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
     </ul>
-    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
       <!---->
     </div>
     <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPointsWithAnotherLegacyGeoSysteme.html
+++ b/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPointsWithAnotherLegacyGeoSysteme.html
@@ -298,12 +298,12 @@
   </defs>
 </svg>
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
       <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
       <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
     </ul>
-    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
       <!---->
     </div>
     <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPointsWithoutNameAndDesc.html
+++ b/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_CustomPointsWithoutNameAndDesc.html
@@ -298,12 +298,12 @@
   </defs>
 </svg>
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
       <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
       <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
     </ul>
-    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
       <!---->
     </div>
     <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_MultiplePolygonWithLacuneTableau.html
+++ b/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_MultiplePolygonWithLacuneTableau.html
@@ -298,12 +298,12 @@
   </defs>
 </svg>
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
       <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
       <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
     </ul>
-    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
       <!---->
     </div>
     <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_WithForages.html
+++ b/packages/ui/src/components/_common/dsfr-perimetre.stories_snapshots_WithForages.html
@@ -1,10 +1,10 @@
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
       <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
       <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
     </ul>
-    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+    <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
       <!---->
     </div>
     <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/_common/storybook.spec.ts
+++ b/packages/ui/src/components/_common/storybook.spec.ts
@@ -47,6 +47,22 @@ describe('Common Storybook Tests', async () => {
       try {
         // @ts-ignore
         window.dsfr = null
+
+        class ResizeObserver {
+          observe() {
+            // do nothing
+          }
+
+          unobserve() {
+            // do nothing
+          }
+
+          disconnect() {
+            // do nothing
+          }
+        }
+
+        global.ResizeObserver = ResizeObserver
         const mounted = render(value.story(), {
           global: {
             components: { 'router-link': (props, { slots }) => h('a', { ...props, type: 'primary', to: JSON.stringify(props.to).replaceAll('"', '') }, slots) },

--- a/packages/ui/src/components/_ui/storybook.spec.ts
+++ b/packages/ui/src/components/_ui/storybook.spec.ts
@@ -47,6 +47,21 @@ describe('UI Storybook Tests', async () => {
       try {
         // @ts-ignore
         window.dsfr = null
+        class ResizeObserver {
+          observe() {
+            // do nothing
+          }
+
+          unobserve() {
+            // do nothing
+          }
+
+          disconnect() {
+            // do nothing
+          }
+        }
+
+        global.ResizeObserver = ResizeObserver
         const mounted = render(value.story(), {
           global: {
             components: { 'router-link': (props, { slots }) => h('a', { ...props, type: 'primary', to: JSON.stringify(props.to).replaceAll('"', '') }, slots) },

--- a/packages/ui/src/components/_ui/tabs.stories_snapshots_SecondTabInit.html
+++ b/packages/ui/src/components/_ui/tabs.stories_snapshots_SecondTabInit.html
@@ -1,10 +1,10 @@
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Titre d’accessibilité des onglets">
       <li role="presentation"><button id="tabpanel-tabId1-271" class="fr-tabs__tab fr-icon-tiktok-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="titreTab 1" aria-selected="false" aria-controls="tabpanel-tabId1-271-panel">titreTab 1</button></li>
       <li role="presentation"><button id="tabpanel-tabId2-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="titreTab 2" aria-selected="true" aria-controls="tabpanel-tabId2-271-panel">titreTab 2</button></li>
     </ul>
-    <div id="tabpanel-tabId1-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-tabId1-271" tabindex="0">
+    <div id="tabpanel-tabId1-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-tabId1-271" tabindex="0">
       <!---->
     </div>
     <div id="tabpanel-tabId2-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-tabId2-271" tabindex="0">

--- a/packages/ui/src/components/_ui/tabs.stories_snapshots_Simple.html
+++ b/packages/ui/src/components/_ui/tabs.stories_snapshots_Simple.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="fr-tabs">
+  <div class="fr-tabs" style="--tabs-height: 0px;">
     <ul class="fr-tabs__list" role="tablist" aria-label="Titre d’accessibilité des onglets">
       <li role="presentation"><button id="tabpanel-tabId1-271" class="fr-tabs__tab fr-icon-tiktok-fill fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="titreTab 1" aria-selected="true" aria-controls="tabpanel-tabId1-271-panel">titreTab 1</button></li>
       <li role="presentation"><button id="tabpanel-tabId2-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="titreTab 2" aria-selected="false" aria-controls="tabpanel-tabId2-271-panel">titreTab 2</button></li>
@@ -7,7 +7,7 @@
     <div id="tabpanel-tabId1-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-tabId1-271" tabindex="0">
       <h1>Content of tab 1</h1>
     </div>
-    <div id="tabpanel-tabId2-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-tabId2-271" tabindex="0">
+    <div id="tabpanel-tabId2-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-end" role="tabpanel" aria-labelledby="tabpanel-tabId2-271" tabindex="0">
       <!---->
     </div>
   </div>

--- a/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_AxmDeposableAvecDaeEtAsl.html
+++ b/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_AxmDeposableAvecDaeEtAsl.html
@@ -46,12 +46,12 @@
     </div>
   </div>
   <div class="fr-pt-2w">
-    <div class="fr-tabs">
+    <div class="fr-tabs" style="--tabs-height: 0px;">
       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
         <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
         <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
       </ul>
-      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
         <!---->
       </div>
       <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeArmMecaniseDeposable.html
+++ b/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeArmMecaniseDeposable.html
@@ -65,12 +65,12 @@
     <!---->
   </div>
   <div class="fr-pt-2w">
-    <div class="fr-tabs">
+    <div class="fr-tabs" style="--tabs-height: 0px;">
       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
         <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
         <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
       </ul>
-      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
         <!---->
       </div>
       <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeArmMecaniseNonDeposable.html
+++ b/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeArmMecaniseNonDeposable.html
@@ -65,12 +65,12 @@
     <!---->
   </div>
   <div class="fr-pt-2w">
-    <div class="fr-tabs">
+    <div class="fr-tabs" style="--tabs-height: 0px;">
       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
         <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
         <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
       </ul>
-      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
         <!---->
       </div>
       <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeArmNonMecaniseDeposable.html
+++ b/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeArmNonMecaniseDeposable.html
@@ -65,12 +65,12 @@
     <!---->
   </div>
   <div class="fr-pt-2w">
-    <div class="fr-tabs">
+    <div class="fr-tabs" style="--tabs-height: 0px;">
       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
         <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
         <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
       </ul>
-      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
         <!---->
       </div>
       <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeAvecForage.html
+++ b/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeAvecForage.html
@@ -41,12 +41,12 @@
     </div>
   </div>
   <div class="fr-pt-2w">
-    <div class="fr-tabs">
+    <div class="fr-tabs" style="--tabs-height: 0px;">
       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
         <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
         <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
       </ul>
-      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
         <!---->
       </div>
       <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeAvecGrosseNote.html
+++ b/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeAvecGrosseNote.html
@@ -34,12 +34,12 @@
     </div>
   </div>
   <div class="fr-pt-2w">
-    <div class="fr-tabs">
+    <div class="fr-tabs" style="--tabs-height: 0px;">
       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
         <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
         <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
       </ul>
-      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
         <!---->
       </div>
       <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeAvecSeulementPerimetre.html
+++ b/packages/ui/src/components/demarche/demarche-etape.stories_snapshots_DemandeAvecSeulementPerimetre.html
@@ -13,12 +13,12 @@
   </div>
   <!---->
   <div class="fr-pt-2w">
-    <div class="fr-tabs">
+    <div class="fr-tabs" style="--tabs-height: 0px;">
       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
         <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
         <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
       </ul>
-      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+      <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
         <!---->
       </div>
       <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/etape-edition.stories_snapshots_DemandeArmComplete.html
+++ b/packages/ui/src/components/etape-edition.stories_snapshots_DemandeArmComplete.html
@@ -145,12 +145,12 @@
                 <!---->
                 <div class="fr-mt-2w">
                   <div>
-                    <div class="fr-tabs">
+                    <div class="fr-tabs" style="--tabs-height: 0px;">
                       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                         <li role="presentation"><button id="tabpanel-carte-772" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-772-panel">Carte</button></li>
                         <li role="presentation"><button id="tabpanel-points-772" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-772-panel">Tableau</button></li>
                       </ul>
-                      <div id="tabpanel-carte-772-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-772" tabindex="0">
+                      <div id="tabpanel-carte-772-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-772" tabindex="0">
                         <!---->
                       </div>
                       <div id="tabpanel-points-772-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-772" tabindex="0">

--- a/packages/ui/src/components/etape-edition.stories_snapshots_ModificationDemandeHeritee.html
+++ b/packages/ui/src/components/etape-edition.stories_snapshots_ModificationDemandeHeritee.html
@@ -182,12 +182,12 @@
               <div>
                 <div>
                   <div>
-                    <div class="fr-tabs">
+                    <div class="fr-tabs" style="--tabs-height: 0px;">
                       <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                         <li role="presentation"><button id="tabpanel-carte-58" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-58-panel">Carte</button></li>
                         <li role="presentation"><button id="tabpanel-points-58" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-58-panel">Tableau</button></li>
                       </ul>
-                      <div id="tabpanel-carte-58-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-58" tabindex="0">
+                      <div id="tabpanel-carte-58-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-58" tabindex="0">
                         <!---->
                       </div>
                       <div id="tabpanel-points-58-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-58" tabindex="0">

--- a/packages/ui/src/components/etape/etape-edit-form.stories_snapshots_EtapeModification.html
+++ b/packages/ui/src/components/etape/etape-edit-form.stories_snapshots_EtapeModification.html
@@ -199,12 +199,12 @@
               <!---->
               <div class="fr-mt-2w">
                 <div>
-                  <div class="fr-tabs">
+                  <div class="fr-tabs" style="--tabs-height: 0px;">
                     <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                       <li role="presentation"><button id="tabpanel-carte-267" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-267-panel">Carte</button></li>
                       <li role="presentation"><button id="tabpanel-points-267" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-267-panel">Tableau</button></li>
                     </ul>
-                    <div id="tabpanel-carte-267-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-267" tabindex="0">
+                    <div id="tabpanel-carte-267-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-267" tabindex="0">
                       <!---->
                     </div>
                     <div id="tabpanel-points-267-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-267" tabindex="0">

--- a/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_FilledNoHeritage.html
+++ b/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_FilledNoHeritage.html
@@ -5,12 +5,12 @@
       <!---->
       <div class="fr-mt-2w">
         <div>
-          <div class="fr-tabs">
+          <div class="fr-tabs" style="--tabs-height: 0px;">
             <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
               <li role="presentation"><button id="tabpanel-carte-670" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-670-panel">Carte</button></li>
               <li role="presentation"><button id="tabpanel-points-670" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-670-panel">Tableau</button></li>
             </ul>
-            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
+            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
               <!---->
             </div>
             <div id="tabpanel-points-670-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-670" tabindex="0">

--- a/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_Heritage.html
+++ b/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_Heritage.html
@@ -3,12 +3,12 @@
     <div>
       <div>
         <div>
-          <div class="fr-tabs">
+          <div class="fr-tabs" style="--tabs-height: 0px;">
             <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
               <li role="presentation"><button id="tabpanel-carte-670" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-670-panel">Carte</button></li>
               <li role="presentation"><button id="tabpanel-points-670" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-670-panel">Tableau</button></li>
             </ul>
-            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
+            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
               <!---->
             </div>
             <div id="tabpanel-points-670-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-670" tabindex="0">

--- a/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_LegacyGeoSysteme.html
+++ b/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_LegacyGeoSysteme.html
@@ -5,12 +5,12 @@
       <!---->
       <div class="fr-mt-2w">
         <div>
-          <div class="fr-tabs">
+          <div class="fr-tabs" style="--tabs-height: 0px;">
             <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
               <li role="presentation"><button id="tabpanel-carte-670" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-670-panel">Carte</button></li>
               <li role="presentation"><button id="tabpanel-points-670" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-670-panel">Tableau</button></li>
             </ul>
-            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
+            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
               <!---->
             </div>
             <div id="tabpanel-points-670-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-670" tabindex="0">

--- a/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_WithForages.html
+++ b/packages/ui/src/components/etape/perimetre-edit.stories_snapshots_WithForages.html
@@ -4,12 +4,12 @@
       <!---->
       <div class="fr-mt-2w">
         <div>
-          <div class="fr-tabs">
+          <div class="fr-tabs" style="--tabs-height: 0px;">
             <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
               <li role="presentation"><button id="tabpanel-carte-670" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-670-panel">Carte</button></li>
               <li role="presentation"><button id="tabpanel-points-670" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-670-panel">Tableau</button></li>
             </ul>
-            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
+            <div id="tabpanel-carte-670-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-670" tabindex="0">
               <!---->
             </div>
             <div id="tabpanel-points-670-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-670" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_AbattisKoticaOctroi.html
+++ b/packages/ui/src/components/titre.stories_snapshots_AbattisKoticaOctroi.html
@@ -117,12 +117,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -272,12 +272,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_BasseManaMod.html
+++ b/packages/ui/src/components/titre.stories_snapshots_BasseManaMod.html
@@ -128,12 +128,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -444,12 +444,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_BonEspoirOctroi.html
+++ b/packages/ui/src/components/titre.stories_snapshots_BonEspoirOctroi.html
@@ -144,12 +144,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -355,12 +355,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_BonEspoirProlongation2.html
+++ b/packages/ui/src/components/titre.stories_snapshots_BonEspoirProlongation2.html
@@ -151,12 +151,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_ChantepieMutation.html
+++ b/packages/ui/src/components/titre.stories_snapshots_ChantepieMutation.html
@@ -113,12 +113,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_ChantepieOctroi.html
+++ b/packages/ui/src/components/titre.stories_snapshots_ChantepieOctroi.html
@@ -113,12 +113,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -257,12 +257,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">
@@ -387,12 +387,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-967" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-967-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-967" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-967-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-967-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-967" tabindex="0">
+                  <div id="tabpanel-carte-967-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-967" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-967-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-967" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_ChantepieOctroiAsEntreprise.html
+++ b/packages/ui/src/components/titre.stories_snapshots_ChantepieOctroiAsEntreprise.html
@@ -112,12 +112,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -255,12 +255,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">
@@ -383,12 +383,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-967" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-967-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-967" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-967-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-967-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-967" tabindex="0">
+                  <div id="tabpanel-carte-967-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-967" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-967-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-967" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_CriqueAdolpheOctroi.html
+++ b/packages/ui/src/components/titre.stories_snapshots_CriqueAdolpheOctroi.html
@@ -120,12 +120,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -449,12 +449,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_Full.html
+++ b/packages/ui/src/components/titre.stories_snapshots_Full.html
@@ -97,12 +97,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -226,12 +226,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">

--- a/packages/ui/src/components/titre.stories_snapshots_Lenoncourt.html
+++ b/packages/ui/src/components/titre.stories_snapshots_Lenoncourt.html
@@ -125,12 +125,12 @@
         </div>
       </div>
       <div class="fr-pt-3w">
-        <div class="fr-tabs">
+        <div class="fr-tabs" style="--tabs-height: 0px;">
           <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
             <li role="presentation"><button id="tabpanel-carte-271" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-271-panel">Carte</button></li>
             <li role="presentation"><button id="tabpanel-points-271" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-271-panel">Tableau</button></li>
           </ul>
-          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
+          <div id="tabpanel-carte-271-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-271" tabindex="0">
             <!---->
           </div>
           <div id="tabpanel-points-271-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-271" tabindex="0">
@@ -384,12 +384,12 @@
                 <!---->
               </div>
               <div class="fr-pt-2w">
-                <div class="fr-tabs">
+                <div class="fr-tabs" style="--tabs-height: 0px;">
                   <ul class="fr-tabs__list" role="tablist" aria-label="Affichage des titres en vue carte ou tableau">
                     <li role="presentation"><button id="tabpanel-carte-74" class="fr-tabs__tab fr-icon-earth-fill fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-label="Carte" aria-selected="false" aria-controls="tabpanel-carte-74-panel">Carte</button></li>
                     <li role="presentation"><button id="tabpanel-points-74" class="fr-tabs__tab fr-icon-list-unordered fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-label="Tableau" aria-selected="true" aria-controls="tabpanel-points-74-panel">Tableau</button></li>
                   </ul>
-                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
+                  <div id="tabpanel-carte-74-panel" class="fr-tabs__panel fr-tabs__panel--direction-start" role="tabpanel" aria-labelledby="tabpanel-carte-74" tabindex="0">
                     <!---->
                   </div>
                   <div id="tabpanel-points-74-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-points-74" tabindex="0">

--- a/packages/ui/src/storybook.spec.ts
+++ b/packages/ui/src/storybook.spec.ts
@@ -50,6 +50,22 @@ describe('Storybook Tests', async () => {
       try {
         // @ts-ignore
         window.dsfr = null
+
+        class ResizeObserver {
+          observe() {
+            // do nothing
+          }
+
+          unobserve() {
+            // do nothing
+          }
+
+          disconnect() {
+            // do nothing
+          }
+        }
+
+        global.ResizeObserver = ResizeObserver
         const mounted = render(value.story(), {
           global: {
             components: { 'router-link': (props, { slots }) => h('a', { ...props, type: 'primary', to: JSON.stringify(props.to).replaceAll('"', '') }, slots) },


### PR DESCRIPTION
- [ ] Les 2 tabs (Carte / Tableau) sur la pages d’accueil fonctionnent comme avant
- [ ] Idem sur la page Statistiques
- [ ] Idem sur la page d’un titre sur le périmètre 