### PR TITLE
fix(titre): ne peut plus accéder au doublon après suppression

### DIFF
--- a/packages/api/src/api/rest/titres.queries.ts
+++ b/packages/api/src/api/rest/titres.queries.ts
@@ -5,6 +5,7 @@ import { Redefine, dbQueryAndValidate } from '../../pg-database.js'
 import {
   IGetAdministrationsLocalesByTitreIdDbQuery,
   IGetDemarchesByTitreIdQueryDbQuery,
+  IGetDoublonsByTitreIdDbQuery,
   IGetTitreByIdOrSlugDbQuery,
   IGetTitreInternalQuery,
   IGetTitulairesAmodiatairesByTitreIdDbQuery,
@@ -300,8 +301,8 @@ from
     titres t
     left join titres t_doublon on t_doublon.id = t.doublon_titre_id
 where
-    t.id = $ id !
-    or t.slug = $ id !
+    (t.id = $ id !
+    or t.slug = $ id !) AND t.archive is false
 LIMIT 1
 `
 
@@ -412,3 +413,17 @@ from
 where
     t.id = $ titreId !
 `
+export const getDoublonsByTitreId = async (pool: Pool, titreId: TitreId): Promise<TitreId[]> => {
+  const result = await dbQueryAndValidate(getDoublonsByTitreIdDb, { titreId }, pool, z.object({ titre_id: titreIdValidator }))
+
+  return result.map(({ titre_id }) => titre_id)
+}
+
+const getDoublonsByTitreIdDb = sql<Redefine<IGetDoublonsByTitreIdDbQuery, { titreId: TitreId }, { titre_id: TitreId }>>`
+  select
+    t.id as titre_id
+  from titres t
+  where
+    t.doublon_titre_id = $ titreId !
+    and t.archive is false
+  `

--- a/packages/api/src/api/rest/titres.queries.types.ts
+++ b/packages/api/src/api/rest/titres.queries.types.ts
@@ -102,3 +102,19 @@ export interface IGetAdministrationsLocalesByTitreIdDbQuery {
   result: IGetAdministrationsLocalesByTitreIdDbResult;
 }
 
+/** 'GetDoublonsByTitreIdDb' parameters type */
+export interface IGetDoublonsByTitreIdDbParams {
+  titreId: string;
+}
+
+/** 'GetDoublonsByTitreIdDb' return type */
+export interface IGetDoublonsByTitreIdDbResult {
+  titre_id: string;
+}
+
+/** 'GetDoublonsByTitreIdDb' query type */
+export interface IGetDoublonsByTitreIdDbQuery {
+  params: IGetDoublonsByTitreIdDbParams;
+  result: IGetDoublonsByTitreIdDbResult;
+}
+

--- a/packages/api/src/api/rest/titres.test.integration.ts
+++ b/packages/api/src/api/rest/titres.test.integration.ts
@@ -408,6 +408,7 @@ describe('getTitre', () => {
       titreStatutId: 'ind',
       slug: titreSlugValidator.parse('arm-slug'),
       propsTitreEtapesIds: {},
+      archive: false,
     })
 
     const tested = await restCall(dbPool, '/rest/titres/:titreId', { titreId }, userSuper)
@@ -428,6 +429,24 @@ describe('getTitre', () => {
       }
     `)
   })
+  test('ne peut pas récupérer un titre archivé', async () => {
+    const titreId = newTitreId('archive-titre-id')
+    await Titres.query().insert({
+      id: titreId,
+      nom: 'mon nouveau titre',
+      typeId: 'arm',
+      titreStatutId: 'ind',
+      slug: titreSlugValidator.parse('arm-slug'),
+      propsTitreEtapesIds: {},
+      archive: true,
+    })
+
+    const tested = await restCall(dbPool, '/rest/titres/:titreId', { titreId }, userSuper)
+
+    expect(tested.statusCode).toBe(404)
+    expect(tested.body).toMatchInlineSnapshot(`{}`)
+  })
+
   test('peut récupérer un titre avec des administrations locales', async () => {
     const titreId = newTitreId('titre-id')
     await Titres.query().insert({
@@ -437,6 +456,7 @@ describe('getTitre', () => {
       slug: titreSlugValidator.parse('slug'),
       titreStatutId: 'val',
       propsTitreEtapesIds: {},
+      archive: false,
     })
 
     const demarcheId = newDemarcheId('demarche-id')

--- a/packages/api/src/business/utils/titre-slug-and-relations-update.ts
+++ b/packages/api/src/business/utils/titre-slug-and-relations-update.ts
@@ -90,7 +90,7 @@ const relationsSlugsUpdate = async (parent: any, relations: (ITitreRelation<Dema
 
 export const titreSlugAndRelationsUpdate = async (titre: ITitre): Promise<{ hasChanged: boolean; slug: TitreSlug }> => {
   let slug = titreSlugFind(titre)
-  let doublonTitreId: string | null = null
+  let doublonTitreId: TitreId | null = null
   let hasChanged = false
 
   const titreWithTheSameSlug = await titresGet({ slugs: [slug] }, { fields: { id: {} } }, userSuper)
@@ -104,7 +104,7 @@ export const titreSlugAndRelationsUpdate = async (titre: ITitre): Promise<{ hasC
     }
   }
 
-  if (titre.slug !== slug) {
+  if (titre.slug !== slug || (titre.doublonTitreId ?? null) !== doublonTitreId) {
     await titreUpdate(titre.id, { slug, doublonTitreId })
     hasChanged = true
   }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -189,7 +189,7 @@ interface ITitre {
   activites?: ITitreActivite[] | null
   publicLecture?: boolean | null
   propsTitreEtapesIds: IPropsTitreEtapesIds
-  doublonTitreId?: string | null
+  doublonTitreId?: TitreId | null
   confidentiel?: boolean | null
 
   geojson4326Centre?: GeojsonPoint | null


### PR DESCRIPTION
 - [ ] Quand on supprime un titre, on ne peut plus y accéder via son url
 - [ ] Quand on supprime un doublon, le bandeau qui indique qu’il y a un doublon disparait