### PR TITLE
fix(ui): le zoom automatique sur la région d'une administration est plus précis

### DIFF
--- a/packages/ui/src/components/_common/filtres.tsx
+++ b/packages/ui/src/components/_common/filtres.tsx
@@ -37,9 +37,12 @@ export const Filtres = defineComponent((props: Props) => {
       // pour les prendre en compte lorsqu'on valide en appuyant sur "entrée"
       // met le focus sur le bouton de validation (dans la méthode close())
       close()
+      // TODO 2024-05-29 ici on clone car, par un hasard étrange, on se retrouve parfois avec la même référence d'objet qui est passée tout le temps, du coup validate est appelé avec la même valeur que filtresValues alors que ça vient de changer...'
+      // Il faut qu'on change ce comportement, probablement en faisant en sorte que les filtres utilisent le routeur, et que personne d'autre ne s'en serve pour calculer les filtres initiaux, mais utilisent plutôt les callback des filtres
+      const newParams = structuredClone(params)
 
-      filtresValues.value = params
-      props.paramsUpdate(params)
+      filtresValues.value = newParams
+      props.paramsUpdate(newParams)
     }
   }
 

--- a/packages/ui/src/components/_map/index.tsx
+++ b/packages/ui/src/components/_map/index.tsx
@@ -188,6 +188,7 @@ export const CaminoMap = defineComponent<Props>((props, { expose }) => {
     if (map.value !== null) {
       const leafletComponentOnMounted = markRaw(
         L.map(map.value, {
+          zoomSnap: 0,
           zoomControl: true,
           zoomAnimation: false,
           doubleClickZoom: false,

--- a/packages/ui/src/router/index.tsx
+++ b/packages/ui/src/router/index.tsx
@@ -404,7 +404,7 @@ router.beforeEach(async (to, from, next) => {
   document.title = typeof to.meta.title === 'string' ? `${to.meta.title} - Camino` : 'le cadastre minier numérique ouvert - Camino'
   // Ceci est pour empêcher de nettoyer les filtres quand on clique sur le menu.
   // Par exemple sur "titres et autorisations" , après avoir rajouter des filtres, si on clique à nouveau sur le menu, on perd tous les filtres
-  if (from.name === to.name && isNullOrUndefinedOrEmpty(Object.keys(to.query))) {
+  if (from.name === to.name && JSON.stringify(to.params) === JSON.stringify(from.params) && isNullOrUndefinedOrEmpty(Object.keys(to.query))) {
     next(false)
   } else {
     next()

--- a/packages/ui/src/router/index.tsx
+++ b/packages/ui/src/router/index.tsx
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 import { Dashboard } from '../components/dashboard'
 import { Titres } from '../components/titres'
 import { Alert } from '@/components/_ui/alert'
+import { isNullOrUndefinedOrEmpty } from 'camino-common/src/typescript-tools'
 
 const DGTMStatsFull = async () => {
   const { DGTMStatsFull } = await import('../components/dashboard/dgtm-stats-full')
@@ -369,9 +370,8 @@ const routes = [
       menuSection: null,
     },
   },
-] as const satisfies Readonly<(Omit<RouteRecordRaw, 'children'> & { children?: Readonly<RouteRecordRaw['children']> })[]>
+] as const satisfies Readonly<Omit<RouteRecordRaw, 'children'>[]>
 
-// TODO 2023-06-29 make children
 export type CaminoRoutePaths = (typeof routes)[number]['path']
 
 const history = createWebHistory()
@@ -402,8 +402,13 @@ router.isReady().then(async () => {})
 
 router.beforeEach(async (to, from, next) => {
   document.title = typeof to.meta.title === 'string' ? `${to.meta.title} - Camino` : 'le cadastre minier numérique ouvert - Camino'
-
-  next()
+  // Ceci est pour empêcher de nettoyer les filtres quand on clique sur le menu.
+  // Par exemple sur "titres et autorisations" , après avoir rajouter des filtres, si on clique à nouveau sur le menu, on perd tous les filtres
+  if (from.name === to.name && isNullOrUndefinedOrEmpty(Object.keys(to.query))) {
+    next(false)
+  } else {
+    next()
+  }
 })
 
 export default router


### PR DESCRIPTION
Maintenant, on ne réinitialise plus la page quand on clique sur le lien d'une page sur laquelle on est.

Par exemple, sur la page "titres et autorisations", si on rajoute des filtres, puis qu'on clique sur le lien "titres et autorisations", ça réinitialisait tous les filtres, plus maintenant.

Corrige la:
  * #1180 
