### PR TITLE
chore(infra): limite la taille du journal à 1G

### DIFF
--- a/infra/roles/init/tasks/main.yml
+++ b/infra/roles/init/tasks/main.yml
@@ -26,7 +26,7 @@
   block:
     - name: Install tools for apt
       ansible.builtin.apt:
-        name: 
+        name:
           - ca-certificates
           - curl
           - gnupg
@@ -75,4 +75,19 @@
         mode: u=rwx,g=rx,o=r
         owner: camino
         group: users
+      become: True
+- name: journalctl
+  block:
+    - name: Limite la taille maximum des fichiers de logs à 1GB
+      ansible.builtin.lineinfile:
+        path: /etc/systemd/journald.conf
+        regexp: '^SystemMaxUse='
+        line: SystemMaxUse=1G
+      become: True
+      register: limit_journal_size
+    - name: Redémarre systemd-journald
+      ansible.builtin.systemd_service:
+        state: restarted
+        name: systemd-journald
+      when: limit_journal_size.changed
       become: True


### PR DESCRIPTION
En dev, preprod et prod, ça prend plus de 2G pour rien.

Pour vérifier que ça fonctionne bien, sur la machine, faire `sudo systemctl status systemd-journald` et on doit voir une ligne comme ça:

`System Journal (/var/log/journal/2ad851a335d342ae861ba1c6ca8c62fa) is 40.0M, max 1.0G, 983.9M free.`
