### PR TITLE
feat(api): enregistre les actions (mutations POST/PUT/DELETE) des utilisateurs

### DIFF
--- a/packages/api/src/api/rest/logs.queries.ts
+++ b/packages/api/src/api/rest/logs.queries.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-restricted-syntax */
+import { sql } from '@pgtyped/runtime'
+import { Redefine, dbQueryAndValidate } from '../../pg-database.js'
+import { Pool } from 'pg'
+import { z } from 'zod'
+import { IInsertLogInternalQuery } from './logs.queries.types.js'
+import { UtilisateurId } from 'camino-common/src/roles.js'
+
+export const addLog = async (pool: Pool, utilisateur_id: UtilisateurId, method: string, path: string, body?: unknown) =>
+  dbQueryAndValidate(insertLogInternal, { utilisateur_id, method, path, body }, pool, z.void())
+
+const insertLogInternal = sql<
+  Redefine<
+    IInsertLogInternalQuery,
+    {
+      utilisateur_id: UtilisateurId
+      method: string
+      path: string
+      body?: unknown
+    },
+    void
+  >
+>`
+insert into logs (utilisateur_id, path, method, body)
+    values ($ utilisateur_id !, $path !, $ method !, $ body)
+;
+`

--- a/packages/api/src/api/rest/logs.queries.types.ts
+++ b/packages/api/src/api/rest/logs.queries.types.ts
@@ -1,0 +1,20 @@
+/** Types generated for queries found in "src/api/rest/logs.queries.ts" */
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+
+/** 'InsertLogInternal' parameters type */
+export interface IInsertLogInternalParams {
+  body?: Json | null | void;
+  method: string;
+  path: string;
+  utilisateur_id: string;
+}
+
+/** 'InsertLogInternal' return type */
+export type IInsertLogInternalResult = void;
+
+/** 'InsertLogInternal' query type */
+export interface IInsertLogInternalQuery {
+  params: IInsertLogInternalParams;
+  result: IInsertLogInternalResult;
+}
+

--- a/packages/api/src/api/rest/titres.test.integration.ts
+++ b/packages/api/src/api/rest/titres.test.integration.ts
@@ -294,7 +294,7 @@ describe('titreModifier', () => {
   test('ne peut pas modifier un titre (utilisateur anonyme)', async () => {
     const tested = await restPostCall(dbPool, '/rest/titres/:titreId', { titreId: id }, undefined, { id, nom: 'mon titre modifié', references: [] })
 
-    expect(tested.statusCode).toBe(404)
+    expect(tested.statusCode).toBe(403)
   })
 
   test("ne peut pas modifier un titre (un utilisateur 'entreprise')", async () => {
@@ -377,7 +377,7 @@ describe('titreSupprimer', () => {
   test('ne peut pas supprimer un titre (utilisateur anonyme)', async () => {
     const tested = await restDeleteCall(dbPool, '/rest/titres/:titreId', { titreId: id }, undefined)
 
-    expect(tested.statusCode).toBe(404)
+    expect(tested.statusCode).toBe(403)
   })
 
   test('peut supprimer un titre (utilisateur super)', async () => {

--- a/packages/api/src/knex/migrations/20240530125050_add-logs.ts
+++ b/packages/api/src/knex/migrations/20240530125050_add-logs.ts
@@ -1,0 +1,10 @@
+import { Knex } from 'knex'
+
+export const up = async (knex: Knex) => {
+  await knex.raw(
+    'CREATE TABLE logs(datetime timestamp with time zone NOT NULL default now(), path character varying(255), method character varying(6) NOT NULL, body jsonb default null, utilisateur_id character varying(255) NOT NULL)'
+  )
+  await knex.raw('ALTER TABLE logs ADD CONSTRAINT logs__utilisateur_id__foreign FOREIGN KEY (utilisateur_id) REFERENCES utilisateurs(id)')
+}
+
+export const down = () => ({})


### PR DESCRIPTION
Premier jet lié au plan de remédiation de la conformité au socle technique:
  - #1152

Pour l'instant, pas d'IHM ni rien, juste une sauvegarde brut

En jouant un peu avec dans l'application, ça fonctionne bien, il n'y a pas de souci particulier.
Pour la route des documents par exemple, on ne sait pas quel est le PDF exact envoyé, mais on sait qui a fait quoi sur tel type de document, c'est largement suffisant.

Il nous faut migrer les requêtes graphql qui font des mutations (liste exhaustive):
  - activite-deposer
  - demarche-creer
  - demarche-modifier
  - demarche-supprimer
  - titre-creer
  - etape-creation
  - etape-edition
  
