### PR TITLE
fix(perimetres): gérer l'iso-8859-15 des CSV

### DIFF
--- a/packages/api/src/api/rest/__snapshots__/perimetre.test.integration.ts.snap
+++ b/packages/api/src/api/rest/__snapshots__/perimetre.test.integration.ts.snap
@@ -826,3 +826,50 @@ exports[`geojsonImportForages > csv valide en 2972 1`] = `
   },
 }
 `;
+
+exports[`geojsonImportForages > csv valide en iso-8859-1 1`] = `
+{
+  "geojson4326": {
+    "features": [
+      {
+        "geometry": {
+          "coordinates": [
+            -40.598937151159184,
+            61.54628068732175,
+          ],
+          "type": "Point",
+        },
+        "properties": {
+          "description": "Point A",
+          "nom": "Piézomètre A",
+          "profondeur": 12.12,
+          "type": "rejet",
+        },
+        "type": "Feature",
+      },
+    ],
+    "type": "FeatureCollection",
+  },
+  "origin": {
+    "features": [
+      {
+        "geometry": {
+          "coordinates": [
+            1051195.1083143658,
+            6867800.046355472,
+          ],
+          "type": "Point",
+        },
+        "properties": {
+          "description": "Point A",
+          "nom": "Piézomètre A",
+          "profondeur": 12.12,
+          "type": "rejet",
+        },
+        "type": "Feature",
+      },
+    ],
+    "type": "FeatureCollection",
+  },
+}
+`;

--- a/packages/api/src/api/rest/perimetre.test.integration.ts
+++ b/packages/api/src/api/rest/perimetre.test.integration.ts
@@ -1384,7 +1384,7 @@ B;Point B;1063526.397924559889361;6867885.978687250986695;12.12;12,12`
       {
         "message": "Problème de validation de données",
         "status": 400,
-        "zodErrorReadableMessage": "Validation error: Invalid enum value. Expected 'captage' | 'rejet' | 'piézomètre', received '1212'",
+        "zodErrorReadableMessage": "Validation error: Invalid enum value. Expected 'captage' | 'rejet' | 'piézomètre', received '1212' at "[0].type"; Invalid enum value. Expected 'captage' | 'rejet' | 'piézomètre', received '12,12' at "[1].type"",
       }
     `)
     expect(tested.statusCode).toBe(HTTP_STATUS.HTTP_STATUS_BAD_REQUEST)
@@ -1405,5 +1405,24 @@ B;Point B;1063526.397924559889361;6867885.978687250986695;12.12;captage`
 
     const tested = await restNewPostCall(dbPool, '/rest/geojson_forages/import/:geoSystemeId', { geoSystemeId: GEO_SYSTEME_IDS['RGFG95 / UTM zone 22N'] }, userSuper, body)
     expect(tested.statusCode).toBe(HTTP_STATUS.HTTP_STATUS_BAD_REQUEST)
+  })
+
+  test('csv valide en iso-8859-1', async () => {
+    const fileName = `existing_temp_file_${idGenerate()}.csv`
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      `${dir}/${fileName}`,
+      `nom;description;x;y;profondeur;type
+Piézomètre A;Point A;1051195.108314365847036;6867800.046355471946299;12.12;rejet`,
+      { encoding: 'latin1' }
+    )
+    const body: GeojsonImportForagesBody = {
+      tempDocumentName: tempDocumentNameValidator.parse(fileName),
+      fileType: 'csv',
+    }
+
+    const tested = await restNewPostCall(dbPool, '/rest/geojson_forages/import/:geoSystemeId', { geoSystemeId: GEO_SYSTEME_IDS['RGFG95 / UTM zone 22N'] }, userSuper, body)
+    expect(tested.statusCode).toBe(HTTP_STATUS.HTTP_STATUS_OK)
+    expect(tested.body).toMatchSnapshot()
   })
 })

--- a/packages/api/src/api/rest/perimetre.ts
+++ b/packages/api/src/api/rest/perimetre.ts
@@ -432,10 +432,21 @@ const fileNameToShape = <T extends ZodTypeAny>(pathFrom: string, validator: T): 
     E.flatMap(zodParseEitherCallback(validator))
   )
 }
+
+const readIsoOrUTF8FileSync = (path: string): string => {
+  const buffer = readFileSync(path)
+
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(buffer)
+  } catch (e) {
+    return new TextDecoder('iso-8859-15', { fatal: true }).decode(buffer)
+  }
+}
+
 const fileNameToCsv = (pathFrom: string): E.Either<CaminoError<typeof ouvertureCsvError>, unknown[]> => {
   return E.tryCatch(
     () => {
-      const fileContent = readFileSync(pathFrom, { encoding: 'utf-8' })
+      const fileContent = readIsoOrUTF8FileSync(pathFrom)
       const result = xlsx.read(fileContent, { type: 'string', FS: ';', raw: true })
 
       if (result.SheetNames.length !== 1) {

--- a/packages/common/src/perimetre.test.ts
+++ b/packages/common/src/perimetre.test.ts
@@ -1,6 +1,5 @@
 import { test, expect } from 'vitest'
-import { crsUrnValidator, equalGeojson, featureForagePropertiesValidator } from './perimetre'
-import { z } from 'zod'
+import { crsUrnValidator, equalGeojson } from './perimetre'
 
 test('equalGeojson', () => {
   expect(equalGeojson({ type: 'MultiPolygon', coordinates: [[[[1, 2]]]] }, null)).toBe(false)
@@ -50,30 +49,4 @@ test('crsUrnValidator', () => {
   expect(crsUrnValidator.safeParse('urn:ogc:def:crs:EPSG::PLOP').success).toBe(false)
   expect(crsUrnValidator.safeParse('urn:ogc:def:crs:EPSG::').success).toBe(false)
   expect(crsUrnValidator.safeParse('urn:ogc:def:crs:EPSG::27572').success).toBe(true)
-})
-test('featureForagePropertiesValidator', () => {
-  const featureForageProperties: z.infer<typeof featureForagePropertiesValidator> = {
-    nom: 'A',
-    type: 'piézomètre',
-    profondeur: 0,
-  }
-  const featureForagePropertiesCasse = {
-    nom: 'B',
-    type: 'pi�zom�tre',
-    profondeur: 0,
-  }
-  expect(z.array(featureForagePropertiesValidator).parse([featureForageProperties, featureForagePropertiesCasse])).toMatchInlineSnapshot(`
-    [
-      {
-        "nom": "A",
-        "profondeur": 0,
-        "type": "piézomètre",
-      },
-      {
-        "nom": "B",
-        "profondeur": 0,
-        "type": "piézomètre",
-      },
-    ]
-  `)
 })

--- a/packages/common/src/perimetre.ts
+++ b/packages/common/src/perimetre.ts
@@ -97,7 +97,7 @@ export type ForageType = z.infer<typeof forageTypeValidator>
 export const featureForagePropertiesValidator = z.object({
   nom: z.string().trim().min(1),
   description: z.string().nullish(),
-  type: z.string().transform(value => forageTypeValidator.parse(value)),
+  type: forageTypeValidator,
   profondeur: z.number(),
 })
 const featureForageValidator = z.object({ type: z.literal('Feature'), geometry: pointValidator, properties: featureForagePropertiesValidator })

--- a/packages/common/src/perimetre.ts
+++ b/packages/common/src/perimetre.ts
@@ -97,17 +97,7 @@ export type ForageType = z.infer<typeof forageTypeValidator>
 export const featureForagePropertiesValidator = z.object({
   nom: z.string().trim().min(1),
   description: z.string().nullish(),
-  type: z
-    .string()
-    .transform(value => {
-      // TODO 2024-05-06 ceci est dû au fait que certains utilisateurs sont en ISO-8859-15 et ça pose problème uniquement lors de l'import de CSV des forages, là ou la seule clé possède un accent :(
-      if (value === 'pi�zom�tre') {
-        return 'piézomètre'
-      } else {
-        return value
-      }
-    })
-    .transform(value => forageTypeValidator.parse(value)),
+  type: z.string().transform(value => forageTypeValidator.parse(value)),
   profondeur: z.number(),
 })
 const featureForageValidator = z.object({ type: z.literal('Feature'), geometry: pointValidator, properties: featureForagePropertiesValidator })


### PR DESCRIPTION
On teste un decoding en UTF-8, s'il foire on teste un decoding en iso-8859-15.