### PR TITLE
fix(titre): remet le bandeau des titres en doublon

### DIFF
--- a/packages/api/src/business/utils/titre-slug-and-relations-update.test.integration.ts
+++ b/packages/api/src/business/utils/titre-slug-and-relations-update.test.integration.ts
@@ -93,12 +93,16 @@ describe('vérifie la mis à jour des slugs sur les relations d’un titre', () 
     } as ITitre
 
     let titre = await titreAdd(objectClone(titrePojo))
+    const firstTitreId = titre.id
     const { slug: firstSlug } = await titreSlugAndRelationsUpdate(titre)
     titre = await titreAdd({ ...titrePojo, slug: titreSlugValidator.parse(`${firstSlug}-123123`) })
 
     const { hasChanged, slug: secondSlug } = await titreSlugAndRelationsUpdate(titre)
-    expect(hasChanged).toEqual(false)
+    expect(hasChanged).toEqual(true)
     expect(secondSlug).toEqual(`${firstSlug}-123123`)
+
+    const savedTitre = await titreGet(titre.id, { fields: { id: {} } }, userSuper)
+    expect(savedTitre?.doublonTitreId).toEqual(firstTitreId)
   })
 
   test('génère un slug pour une démarche', async () => {

--- a/packages/api/src/business/utils/titre-slug-and-relations-update.ts
+++ b/packages/api/src/business/utils/titre-slug-and-relations-update.ts
@@ -100,8 +100,8 @@ export const titreSlugAndRelationsUpdate = async (titre: ITitre): Promise<{ hasC
       slug = titre.slug
     } else {
       slug = titreSlugValidator.parse(`${slug}-${idGenerate(8)}`)
-      doublonTitreId = titreWithTheSameSlug[0].id
     }
+    doublonTitreId = titreWithTheSameSlug[0].id
   }
 
   if (titre.slug !== slug || (titre.doublonTitreId ?? null) !== doublonTitreId) {


### PR DESCRIPTION
 - [ ] Quand on supprime un titre, on ne peut plus y accéder via son url
 - [ ] Quand on supprime un doublon, le bandeau qui indique qu’il y a un doublon disparait

Related to:
  * #1191