### PR TITLE
fix(titres): permet administrations locales d'éditer un titre

### DIFF
--- a/packages/api/src/api/rest/titres.ts
+++ b/packages/api/src/api/rest/titres.ts
@@ -214,7 +214,7 @@ export const titresAdministrations = (_pool: Pool) => async (req: CaminoRequest,
           }
 
           return (
-            canEditTitre(user, titre.typeId, titre.titreStatutId) ||
+            canEditTitre(user, titre.typeId, titre.titreStatutId, titre.administrationsLocales ?? []) ||
             canEditDemarche(user, titre.typeId, titre.titreStatutId, titre.administrationsLocales ?? []) ||
             canCreateTravaux(
               user,
@@ -510,12 +510,12 @@ export const updateTitre = (pool: Pool) => async (req: CaminoRequest, res: Custo
     res.sendStatus(HTTP_STATUS.BAD_REQUEST)
   } else {
     try {
-      const titreOld = await titreGet(titreId, { fields: {} }, user)
+      const titreOld = await titreGet(titreId, { fields: { pointsEtape: { id: {} } } }, user)
 
       if (isNullOrUndefined(titreOld)) {
         res.sendStatus(HTTP_STATUS.NOT_FOUND)
       } else {
-        if (!canEditTitre(user, titreOld.typeId, titreOld.titreStatutId)) {
+        if (!canEditTitre(user, titreOld.typeId, titreOld.titreStatutId, titreOld.administrationsLocales ?? [])) {
           res.sendStatus(HTTP_STATUS.FORBIDDEN)
         } else {
           // on doit utiliser upsert (plutôt qu'un simple update)

--- a/packages/api/src/api/rest/titres.ts
+++ b/packages/api/src/api/rest/titres.ts
@@ -511,13 +511,14 @@ export const updateTitre = (pool: Pool) => async (req: CaminoRequest, res: Custo
   } else {
     try {
       const titreOld = await titreGet(titreId, { fields: { pointsEtape: { id: {} } } }, user)
-      if (isNullOrUndefined(titreOld?.administrationsLocales)) {
-        throw new Error("pas d'administrations locales chargées")
-      }
 
       if (isNullOrUndefined(titreOld)) {
         res.sendStatus(HTTP_STATUS.NOT_FOUND)
       } else {
+        if (isNullOrUndefined(titreOld?.administrationsLocales)) {
+          throw new Error("pas d'administrations locales chargées")
+        }
+
         if (!canEditTitre(user, titreOld.typeId, titreOld.titreStatutId, titreOld.administrationsLocales ?? [])) {
           res.sendStatus(HTTP_STATUS.FORBIDDEN)
         } else {

--- a/packages/api/src/api/rest/titres.ts
+++ b/packages/api/src/api/rest/titres.ts
@@ -511,6 +511,9 @@ export const updateTitre = (pool: Pool) => async (req: CaminoRequest, res: Custo
   } else {
     try {
       const titreOld = await titreGet(titreId, { fields: { pointsEtape: { id: {} } } }, user)
+      if (isNullOrUndefined(titreOld?.administrationsLocales)) {
+        throw new Error("pas d'administrations locales chargées")
+      }
 
       if (isNullOrUndefined(titreOld)) {
         res.sendStatus(HTTP_STATUS.NOT_FOUND)

--- a/packages/common/src/permissions/titres.test.ts
+++ b/packages/common/src/permissions/titres.test.ts
@@ -98,20 +98,20 @@ describe('canEditTitre', () => {
   test.each<TitreTypeId>(TitresTypesIds)('vérifie si une entreprise ne peut pas modifier un titre de type %p', titreTypeId => {
     const user: User = { role: 'entreprise', entreprises: [], ...testBlankUser }
     titresStatutsArray.forEach(titreStatut => {
-      expect(canEditTitre(user, titreTypeId, titreStatut.id)).toBe(false)
+      expect(canEditTitre(user, titreTypeId, titreStatut.id, [])).toBe(false)
     })
   })
   test.each<TitreTypeId>(TitresTypesIds)('vérifie si un utilisateur super peut créer un titre de type %p', titreTypeId => {
     const user: User = { role: 'super', ...testBlankUser }
     titresStatutsArray.forEach(titreStatut => {
-      expect(canEditTitre(user, titreTypeId, titreStatut.id)).toBe(true)
+      expect(canEditTitre(user, titreTypeId, titreStatut.id, [])).toBe(true)
     })
   })
 
   test.each<TitreTypeId>(TitresTypesIds)('vérifie si un utilisateur administrateur lecteur ne peut pas modifier de titre de type %p', titreTypeId => {
     const user: User = { role: 'lecteur', administrationId: ADMINISTRATION_IDS['DEAL - MARTINIQUE'], ...testBlankUser }
     titresStatutsArray.forEach(titreStatut => {
-      expect(canEditTitre(user, titreTypeId, titreStatut.id)).toBe(false)
+      expect(canEditTitre(user, titreTypeId, titreStatut.id, [])).toBe(false)
     })
   })
 
@@ -122,7 +122,7 @@ describe('canEditTitre', () => {
       const user: User = { role: 'admin', administrationId, ...testBlankUser }
       for (const titreTypeid of TitresTypesIds) {
         for (const titreStatutId of titresStatutsArray) {
-          const itCan = canEditTitre(user, titreTypeid, titreStatutId.id)
+          const itCan = canEditTitre(user, titreTypeid, titreStatutId.id, [])
           if (itCan) {
             ;((result[administrationId] ??= {})[titreTypeid] ??= {})[titreStatutId.id] = itCan
           }

--- a/packages/common/src/permissions/titres.ts
+++ b/packages/common/src/permissions/titres.ts
@@ -87,11 +87,13 @@ export const canReadTitre = async (
   return false
 }
 
-export const canEditTitre = (user: User, titreTypeId: TitreTypeId, titreStatutId: TitreStatutId): boolean => {
+export const canEditTitre = (user: User, titreTypeId: TitreTypeId, titreStatutId: TitreStatutId, administrationsLocales: AdministrationId[]): boolean => {
   if (isSuper(user)) {
     return true
   } else if (isAdministrationAdmin(user) || isAdministrationEditeur(user)) {
-    return isGestionnaire(user.administrationId, titreTypeId) && canAdministrationModifyTitres(user.administrationId, titreTypeId, titreStatutId)
+    return (
+      (isGestionnaire(user.administrationId, titreTypeId) || administrationsLocales.includes(user.administrationId)) && canAdministrationModifyTitres(user.administrationId, titreTypeId, titreStatutId)
+    )
   }
 
   return false

--- a/packages/ui/src/components/titre.tsx
+++ b/packages/ui/src/components/titre.tsx
@@ -345,7 +345,7 @@ export const PureTitre = defineComponent<Props>(props => {
                   target="_blank"
                   rel="noopener external"
                 />
-                {canEditTitre(props.user, titre.titre_type_id, titre.titre_statut_id) ? (
+                {canEditTitre(props.user, titre.titre_type_id, titre.titre_statut_id, administrations.value) ? (
                   <DsfrButtonIcon icon="fr-icon-pencil-line" buttonType="secondary" class="fr-ml-2w" title="Éditer le titre" onClick={openEditerTitrePopup} />
                 ) : null}
                 {canDeleteTitre(props.user) ? (


### PR DESCRIPTION
- [ ] une administration locale NON gestionnaire peut maintenant éditer un titre et lui mettre une référence