### PR TITLE
fix(etapes): corrige la validation des dates optionnelles de contenu

### DIFF
--- a/packages/api/src/api/_format/titres-etapes.ts
+++ b/packages/api/src/api/_format/titres-etapes.ts
@@ -43,6 +43,7 @@ export const iTitreEtapeToFlattenEtape = (titreEtape: ITitreEtape): FlattenEtape
     throw new Error('pas de slug')
   }
   const contenu = simpleContenuToFlattenedContenu(titreTypeId, demarcheTypeId, titreEtape.typeId, titreEtape.contenu ?? {}, heritageContenuValidator.parse(heritageContenu))
+
   const flattenEtape: FlattenEtape = {
     ...titreEtape,
     slug,

--- a/packages/api/src/api/rest/etapes.ts
+++ b/packages/api/src/api/rest/etapes.ts
@@ -568,6 +568,7 @@ export const createEtape = (pool: Pool) => async (req: CaminoRequest, res: Custo
                     null,
                     null
                   )
+
                   if (rulesErrors.length) {
                     res.status(HTTP_STATUS.BAD_REQUEST).json({ errorMessage: rulesErrors.join(', ') })
                   } else if (

--- a/packages/api/src/business/validations/utils/contenu-dates-check.test.ts
+++ b/packages/api/src/business/validations/utils/contenu-dates-check.test.ts
@@ -38,4 +38,34 @@ describe("vérifie la validité des propriétés dont le type est date d'une ét
       })
     ).toContain('le champ "date" est invalide')
   })
+
+  test('les dates peuvent être obligatoires ou optionnelles', () => {
+    expect(
+      contenuDatesCheck(
+        [
+          {
+            id: 'section',
+            elements: [{ id: 'date', type: 'date', optionnel: false }],
+          },
+        ],
+        {
+          section: { date: { value: null } },
+        }
+      )
+    ).toContain('le champ "date" est invalide')
+
+    expect(
+      contenuDatesCheck(
+        [
+          {
+            id: 'section',
+            elements: [{ id: 'date', type: 'date', optionnel: true }],
+          },
+        ],
+        {
+          section: { date: { value: null } },
+        }
+      )
+    ).toBe(null)
+  })
 })

--- a/packages/api/src/business/validations/utils/contenu-dates-check.ts
+++ b/packages/api/src/business/validations/utils/contenu-dates-check.ts
@@ -9,7 +9,9 @@ export const contenuDatesCheck = (sections: DeepReadonly<Section[]>, contenu: Re
       isNotNullNorUndefinedNorEmpty(section.elements) && isNotNullNorUndefined(contenu[section.id])
         ? section.elements.reduce((errors, element) => {
             if (element.type === 'date' && isNotNullNorUndefined(contenu[section.id][element.id])) {
-              const { success, error } = caminoDateValidator.safeParse(contenu[section.id][element.id].value)
+              const validator = element.optionnel ?? false ? caminoDateValidator.nullable() : caminoDateValidator
+
+              const { success, error } = validator.safeParse(contenu[section.id][element.id].value)
               if (!success) {
                 errors.push(`le champ "${element.id}" est invalide`, error.message)
               }


### PR DESCRIPTION
https://tchap.gouv.fr/#/room/!YAHYlwUZtOTEycSOFg:agent.dinum.tchap.gouv.fr/$9e5BQ9Tp_nOXVgDZGFDUuOJCyPVUAMFYCPHAZHhzXoc?via=agent.dev-durable.tchap.gouv.fr&via=agent.dinum.tchap.gouv.fr&via=agent.interieur.tchap.gouv.fr

- [ ] on peut ajouter une « Notification au demandeur » en ne mettant pas la date de réception