### PR TITLE
chore(api): corrige (ou ignore explicitement) toutes les erreurs de booleans

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,6 +29,7 @@
     "test:unit": "vitest --environment node --root src/ --config ../vitest.unit.config.ts",
     "test:integration": "vitest --environment node --root src/ --config ../vitest.integration.config.ts",
     "test:generate-data": "node --loader ts-node/esm/transpile-only src/tools/demarches/tests-creation.ts",
+    "test:generate-phase-data": "node --loader ts-node/esm/transpile-only src/tools/phases/tests-creation.ts",
     "test:generate-sections-data": "node --loader ts-node/esm/transpile-only src/tools/activites/tests-creation.ts",
     "ci:lint": "prettier --check . && eslint .",
     "matrices": "node --loader ts-node/esm/transpile-only ./src/scripts/matrices.ts"
@@ -204,7 +205,7 @@
         }
       ],
       "@typescript-eslint/explicit-function-return-type": 0,
-      "@typescript-eslint/explicit-module-boundary-types": 0,
+      "@typescript-eslint/explicit-module-boundary-types": "warn",
       "@typescript-eslint/no-empty-interface": 0,
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/no-non-null-assertion": 0,
@@ -217,7 +218,7 @@
           "varsIgnorePattern": "^_"
         }
       ],
-      "@typescript-eslint/strict-boolean-expressions": "warn"
+      "@typescript-eslint/strict-boolean-expressions": "error"
     }
   }
 }

--- a/packages/api/src/api/_format/etapes-types.ts
+++ b/packages/api/src/api/_format/etapes-types.ts
@@ -4,22 +4,23 @@ import { titreDemarcheDepotDemandeDateFind } from '../../business/rules/titre-de
 
 import { DocumentType } from 'camino-common/src/static/documentsTypes.js'
 import { EtapesTypes, EtapeTypeId } from 'camino-common/src/static/etapesTypes.js'
+import { isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools.js'
 
 export const documentsTypesFormat = (documentsTypes: DocumentType[] | undefined | null, documentsTypesSpecifiques: DocumentType[] | undefined | null): DocumentType[] => {
   let result: DocumentType[] = []
 
-  if (documentsTypes?.length) {
+  if (isNotNullNorUndefinedNorEmpty(documentsTypes)) {
     result = [...documentsTypes]
   }
 
-  if (documentsTypesSpecifiques?.length) {
+  if (isNotNullNorUndefinedNorEmpty(documentsTypesSpecifiques)) {
     documentsTypesSpecifiques.forEach(documentTypeSpecifique => {
       const documentType = result.find(({ id }) => id === documentTypeSpecifique.id)
 
       // Si il est déjà présent, on override juste son attribut « optionnel » et sa description
       if (documentType) {
         documentType.optionnel = documentTypeSpecifique.optionnel
-        documentType.description = documentTypeSpecifique.description || documentType.description
+        documentType.description = documentTypeSpecifique.description ?? documentType.description
       } else {
         result.push(documentTypeSpecifique)
       }

--- a/packages/api/src/api/_format/titres-activites.ts
+++ b/packages/api/src/api/_format/titres-activites.ts
@@ -1,5 +1,5 @@
 import { ITitreActivite, IContenu } from '../../types.js'
-import { DeepReadonly } from 'camino-common/src/typescript-tools.js'
+import { DeepReadonly, isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools.js'
 import { Section } from 'camino-common/src/static/titresTypes_demarchesTypes_etapesTypes/sections.js'
 import { Unites } from 'camino-common/src/static/unites.js'
 
@@ -7,7 +7,7 @@ import { Unites } from 'camino-common/src/static/unites.js'
 const titreActiviteContenuFormat = (sections: DeepReadonly<Section[]>, contenu: IContenu) => {
   const section = sections.find(s => s.id === 'substancesFiscales')
 
-  if (section?.elements?.length && contenu?.substancesFiscales) {
+  if (isNotNullNorUndefinedNorEmpty(section?.elements) && isNotNullNorUndefined(contenu?.substancesFiscales)) {
     const substancesFiscalesIds = Object.keys(contenu?.substancesFiscales)
 
     substancesFiscalesIds.forEach(id => {
@@ -15,7 +15,7 @@ const titreActiviteContenuFormat = (sections: DeepReadonly<Section[]>, contenu: 
 
       if (element && (element.type === 'integer' || element.type === 'number') && element.uniteId) {
         const ratio = Unites[element.uniteId].referenceUniteRatio
-        if (ratio) {
+        if (isNotNullNorUndefined(ratio) && ratio > 0) {
           contenu!.substancesFiscales[id] = (contenu!.substancesFiscales[id] as number) / ratio
         }
       }

--- a/packages/api/src/api/_format/titres-demarches.ts
+++ b/packages/api/src/api/_format/titres-demarches.ts
@@ -4,9 +4,10 @@ import { titreEtapeFormat } from './titres-etapes.js'
 import { titreFormat } from './titres.js'
 import { titreDemarcheFormatFields } from './_fields.js'
 import { FieldsDemarche } from '../../database/queries/_options'
+import { isNullOrUndefined } from 'camino-common/src/typescript-tools.js'
 
 export const titreDemarcheFormat = (titreDemarche: ITitreDemarche, fields: FieldsDemarche = titreDemarcheFormatFields) => {
-  if (!fields) return titreDemarche
+  if (isNullOrUndefined(fields)) return titreDemarche
 
   if (fields.titre && titreDemarche.titre) {
     titreDemarche.titre = titreFormat(titreDemarche.titre, fields.titre)

--- a/packages/api/src/api/_format/titres.ts
+++ b/packages/api/src/api/_format/titres.ts
@@ -4,7 +4,7 @@ import { titreActiviteFormat } from './titres-activites.js'
 import { titreDemarcheFormat } from './titres-demarches.js'
 import { titreFormatFields } from './_fields.js'
 import { AdministrationId } from 'camino-common/src/static/administrations.js'
-import { isNullOrUndefined, onlyUnique } from 'camino-common/src/typescript-tools.js'
+import { isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty, isNullOrUndefined, onlyUnique } from 'camino-common/src/typescript-tools.js'
 import { getGestionnairesByTitreTypeId } from 'camino-common/src/static/administrationsTitresTypes.js'
 import { ACTIVITES_STATUTS_IDS } from 'camino-common/src/static/activitesStatuts.js'
 import { FieldsTitre } from '../../database/queries/_options'
@@ -13,7 +13,7 @@ import { FieldsTitre } from '../../database/queries/_options'
 // remplacer le contenu de ce fichier
 // par des requêtes SQL (dans /database/queries/titres)
 // qui retournent les données directement formatées
-export const titreFormat = (t: ITitre, fields: FieldsTitre = titreFormatFields) => {
+export const titreFormat = (t: ITitre, fields: FieldsTitre = titreFormatFields): ITitre => {
   if ((t.confidentiel ?? false) === true) {
     // Si le titre est confidentiel, on a le droit de voir que son périmètre sur la carte
     t = {
@@ -28,7 +28,7 @@ export const titreFormat = (t: ITitre, fields: FieldsTitre = titreFormatFields) 
 
   if (isNullOrUndefined(fields)) return t
 
-  if (fields.demarches && t.demarches?.length) {
+  if (fields.demarches && isNotNullNorUndefinedNorEmpty(t.demarches)) {
     t.demarches = t.demarches.map(td => titreDemarcheFormat(td, fields.demarches))
   }
 
@@ -36,7 +36,7 @@ export const titreFormat = (t: ITitre, fields: FieldsTitre = titreFormatFields) 
     t.surface = t.pointsEtape.surface
   }
 
-  if (fields.activites && t.activites?.length) {
+  if (fields.activites && isNotNullNorUndefinedNorEmpty(t.activites)) {
     t.activites = t.activites.map(ta => {
       ta.titre = t
 
@@ -44,7 +44,7 @@ export const titreFormat = (t: ITitre, fields: FieldsTitre = titreFormatFields) 
     })
   }
 
-  if (t.activites?.length) {
+  if (isNotNullNorUndefinedNorEmpty(t.activites)) {
     t.activitesAbsentes = t.activites.filter(({ activiteStatutId }) => activiteStatutId === ACTIVITES_STATUTS_IDS.ABSENT).length
     t.activitesEnConstruction = t.activites.filter(({ activiteStatutId }) => activiteStatutId === ACTIVITES_STATUTS_IDS.EN_CONSTRUCTION).length
   }
@@ -68,14 +68,13 @@ export const titreAdministrationsGet = (titre: ITitre): AdministrationId[] => {
   return ids.filter(onlyUnique)
 }
 
-export const titresFormat = (titres: ITitre[], fields = titreFormatFields) =>
-  titres &&
-  titres.reduce((acc: ITitre[], titre) => {
+export const titresFormat = (titres: ITitre[], fields = titreFormatFields): ITitre[] =>
+  titres?.reduce((acc: ITitre[], titre) => {
     const titreFormated = titreFormat(titre, fields)
 
-    if (titreFormated) {
+    if (isNotNullNorUndefined(titreFormated)) {
       acc.push(titreFormated)
     }
 
     return acc
-  }, [])
+  }, []) ?? []

--- a/packages/api/src/api/graphql/resolvers/_titre-activite.ts
+++ b/packages/api/src/api/graphql/resolvers/_titre-activite.ts
@@ -7,20 +7,21 @@ import { getPeriode } from 'camino-common/src/static/frequence.js'
 import { ADMINISTRATION_TYPE_IDS, AdministrationId, Administrations } from 'camino-common/src/static/administrations.js'
 import { dateFormat } from 'camino-common/src/date.js'
 import { getElementValeurs, Section, SectionElement } from 'camino-common/src/static/titresTypes_demarchesTypes_etapesTypes/sections.js'
-import { DeepReadonly, NonEmptyArray } from 'camino-common/src/typescript-tools.js'
+import { DeepReadonly, NonEmptyArray, isNotNullNorUndefinedNorEmpty, isNullOrUndefined, isNullOrUndefinedOrEmpty } from 'camino-common/src/typescript-tools.js'
 import { ActivitesTypes } from 'camino-common/src/static/activitesTypes.js'
 import { GetActiviteTypeEmailsByAdministrationIds, getActiviteTypeEmailsByAdministrationIds } from '../../rest/administrations.queries.js'
 import { Pool } from 'pg'
 
 const elementHtmlBuild = (sectionId: string, element: DeepReadonly<SectionElement>, contenu: IContenu) =>
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   contenu[sectionId] && ((contenu[sectionId][element.id] as IContenuValeur) || (contenu[sectionId][element.id] as IContenuValeur) === 0 || (contenu[sectionId][element.id] as IContenuValeur) === false)
-    ? `<li><strong>${element.nom ? element.nom + ' : ' : ''}</strong>${
+    ? `<li><strong>${isNotNullNorUndefinedNorEmpty(element.nom) ? element.nom + ' : ' : ''}</strong>${
         element.type === 'select'
           ? (contenu[sectionId][element.id] as string[])
               .reduce((valeurs: string[], id) => {
                 const valeur = getElementValeurs(element).find(v => v.id === id)
 
-                if (valeur?.nom) {
+                if (isNotNullNorUndefinedNorEmpty(valeur?.nom)) {
                   valeurs.push(valeur.nom)
                 }
 
@@ -32,7 +33,7 @@ const elementHtmlBuild = (sectionId: string, element: DeepReadonly<SectionElemen
     : `<li>–</li>`
 
 const elementsHtmlBuild = (sectionId: string, elements: DeepReadonly<SectionElement[]>, contenu: IContenu) =>
-  elements
+  isNotNullNorUndefinedNorEmpty(elements)
     ? elements.reduce(
         (html, element) => `
 ${html}
@@ -44,9 +45,9 @@ ${elementHtmlBuild(sectionId, element, contenu)}
     : ''
 
 const sectionHtmlBuild = ({ id, nom, elements }: DeepReadonly<Section>, contenu: IContenu) => {
-  const sectionNomHtml = nom ? `<h2>${nom}</h2>` : ''
+  const sectionNomHtml = isNotNullNorUndefinedNorEmpty(nom) ? `<h2>${nom}</h2>` : ''
 
-  const listHtml = elements
+  const listHtml = isNotNullNorUndefinedNorEmpty(elements)
     ? `<ul>
   ${elementsHtmlBuild(id, elements, contenu)}
 </ul>`
@@ -74,7 +75,7 @@ const titreActiviteEmailFormat = ({ contenu, titreId, dateSaisie, sections }: IT
 `
 
   const body =
-    sections && contenu
+    isNotNullNorUndefinedNorEmpty(sections) && contenu
       ? sections.reduce(
           (res, section) => `
 ${res}
@@ -98,21 +99,25 @@ const titreActiviteEmailTitleFormat = (activite: ITitreActivite, titreNom: strin
 }
 
 const titreActiviteUtilisateursEmailsGet = (utilisateurs: IUtilisateur[] | undefined | null): string[] => {
-  return utilisateurs?.filter(u => !!u.email).map(u => u.email!) || []
+  return utilisateurs?.map(u => u.email).filter(isNotNullNorUndefinedNorEmpty) ?? []
 }
 
 export const productionCheck = (activiteTypeId: string, contenu: IContenu | null | undefined): boolean => {
   if (activiteTypeId === 'grx' || activiteTypeId === 'gra') {
     if (contenu?.substancesFiscales) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       return Object.keys(contenu.substancesFiscales).some(key => !!contenu.substancesFiscales[key])
     }
 
     return false
   } else if (activiteTypeId === 'grp') {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     return !!contenu?.renseignements?.orExtrait
   } else if (activiteTypeId === 'wrp') {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const production = contenu?.renseignementsProduction
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     return !!production?.volumeGranulatsExtrait
   }
 
@@ -125,22 +130,20 @@ export const titreActiviteAdministrationsEmailsGet = (
   activiteTypeId: string,
   contenu: IContenu | null | undefined
 ): string[] => {
-  if (!administrationIds || !administrationIds.length) {
+  if (isNullOrUndefinedOrEmpty(administrationIds)) {
     return []
   }
 
-  const activitesTypesEmailsByAdministrationId = (administrationsActivitesTypesEmails ?? []).reduce<Record<AdministrationId, GetActiviteTypeEmailsByAdministrationIds[]>>(
-    (acc, a) => {
-      if (!acc[a.administration_id]) {
-        acc[a.administration_id] = []
-      }
+  const activitesTypesEmailsByAdministrationId = (administrationsActivitesTypesEmails ?? []).reduce<{ [key in AdministrationId]?: GetActiviteTypeEmailsByAdministrationIds[] }>((acc, a) => {
+    const value = acc[a.administration_id]
+    if (isNullOrUndefined(value)) {
+      acc[a.administration_id] = [a]
+    } else {
+      value.push(a)
+    }
 
-      acc[a.administration_id].push(a)
-
-      return acc
-    },
-    {} as Record<AdministrationId, GetActiviteTypeEmailsByAdministrationIds[]>
-  )
+    return acc
+  }, {})
 
   // Si production > 0, envoyer à toutes les administrations liées au titre
   // sinon envoyer seulement aux minitères et aux DREAL
@@ -152,9 +155,9 @@ export const titreActiviteAdministrationsEmailsGet = (
       .filter(administration => production || [ADMINISTRATION_TYPE_IDS.MINISTERE, ADMINISTRATION_TYPE_IDS.DREAL].includes(administration.typeId))
       .filter(administration => Object.keys(activitesTypesEmailsByAdministrationId).includes(administration.id))
       .flatMap(administration => activitesTypesEmailsByAdministrationId[administration.id])
-      .filter(activiteTypeEmail => activiteTypeEmail.activite_type_id === activiteTypeId)
-      .filter(activiteTypeEmail => activiteTypeEmail.email)
-      .map(activiteTypeEmail => activiteTypeEmail.email) ?? []
+      .filter(activiteTypeEmail => activiteTypeEmail?.activite_type_id === activiteTypeId)
+      .map(activiteTypeEmail => activiteTypeEmail?.email)
+      .filter(isNotNullNorUndefinedNorEmpty) ?? []
   )
 }
 

--- a/packages/api/src/api/graphql/resolvers/_titre-etape.ts
+++ b/packages/api/src/api/graphql/resolvers/_titre-etape.ts
@@ -97,6 +97,7 @@ const titreEtapeHeritageContenuBuild = (
       (acc: { [elementId: string]: IHeritageElement }, element) => {
         acc[element.id] = {
           actif: !!titreEtapesFiltered.find(
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             e => e.id !== titreEtape.id && etapeSectionsDictionary[e.id] && etapeSectionsDictionary[e.id].find(s => s.id === section.id && s.elements?.find(el => el.id === element.id))
           ),
         }
@@ -116,6 +117,7 @@ const titreEtapeHeritageContenuBuild = (
   if (heritageContenu) {
     Object.keys(heritageContenu).forEach(sectionId => {
       Object.keys(heritageContenu![sectionId]).forEach(elementId => {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const etapeId = heritageContenu && heritageContenu[sectionId] && heritageContenu[sectionId][elementId].etapeId
 
         if (etapeId) {

--- a/packages/api/src/api/graphql/resolvers/titres-activites.ts
+++ b/packages/api/src/api/graphql/resolvers/titres-activites.ts
@@ -15,7 +15,7 @@ import { userSuper } from '../../../database/user-super.js'
 import { titreGet } from '../../../database/queries/titres.js'
 import { isBureauDEtudes, isEntreprise } from 'camino-common/src/roles.js'
 import { AdministrationId } from 'camino-common/src/static/administrations.js'
-import { isNonEmptyArray, isNullOrUndefined, memoize, onlyUnique } from 'camino-common/src/typescript-tools.js'
+import { isNonEmptyArray, isNotNullNorUndefinedNorEmpty, isNullOrUndefined, memoize, onlyUnique } from 'camino-common/src/typescript-tools.js'
 import { getGestionnairesByTitreTypeId } from 'camino-common/src/static/administrationsTitresTypes.js'
 import { getCurrent } from 'camino-common/src/date.js'
 import { canReadActivites, isActiviteDeposable } from 'camino-common/src/permissions/activites.js'
@@ -94,11 +94,11 @@ export const activites = async (
 
     const fields = fieldsBuild(info)
 
-    if (!intervalle) {
+    if (isNullOrUndefined(intervalle) || intervalle === 0) {
       intervalle = 200
     }
 
-    if (!page) {
+    if (isNullOrUndefined(page) || page === 0) {
       page = 1
     }
 
@@ -221,7 +221,7 @@ export const activiteDeposer = async ({ id }: { id: ActiviteId }, { user, pool }
 
     const administrations: AdministrationId[] = getGestionnairesByTitreTypeId(titre.typeId).map(({ administrationId }) => administrationId)
 
-    if (titre.administrationsLocales?.length) {
+    if (isNotNullNorUndefinedNorEmpty(titre.administrationsLocales)) {
       administrations.push(...titre.administrationsLocales)
     }
 

--- a/packages/api/src/api/rest/format/titres-demarches.ts
+++ b/packages/api/src/api/rest/format/titres-demarches.ts
@@ -16,6 +16,7 @@ import { getCommunesIndex } from '../../../database/queries/communes.js'
 import { EtapesTypes } from 'camino-common/src/static/etapesTypes.js'
 import { EntrepriseId } from 'camino-common/src/entreprise.js'
 import { GetEntreprises, getEntreprises } from '../entreprises.queries.js'
+import { ETAPE_IS_NOT_BROUILLON } from 'camino-common/src/etape.js'
 
 const etapesDatesStatutsBuild = (titreDemarche: ITitreDemarche) => {
   if (isNullOrUndefinedOrEmpty(titreDemarche.etapes)) return null
@@ -23,7 +24,7 @@ const etapesDatesStatutsBuild = (titreDemarche: ITitreDemarche) => {
   const etapes = titreEtapesSortDescByOrdre(titreDemarche.etapes)
 
   return etapes
-    .filter(e => !e.isBrouillon)
+    .filter(e => e.isBrouillon === ETAPE_IS_NOT_BROUILLON)
     .reduce((etapesDatesStatuts, etape) => {
       const type = EtapesTypes[etape.typeId]
 

--- a/packages/api/src/api/rest/format/utilisateurs.ts
+++ b/packages/api/src/api/rest/format/utilisateurs.ts
@@ -5,7 +5,7 @@ import { Administrations } from 'camino-common/src/static/administrations.js'
 export const utilisateursFormatTable = (utilisateurs: IUtilisateur[]) =>
   utilisateurs.map(utilisateur => {
     const user = formatUser(utilisateur)
-    const lien = isAdministration(user) ? [Administrations[user.administrationId].nom] : utilisateur.entreprises?.length ? utilisateur.entreprises.map(a => a.nom) : []
+    const lien = isAdministration(user) ? [Administrations[user.administrationId].nom] : utilisateur.entreprises?.map(a => a.nom) ?? []
 
     return {
       nom: utilisateur.nom,

--- a/packages/api/src/api/rest/statistiques/dgtm.ts
+++ b/packages/api/src/api/rest/statistiques/dgtm.ts
@@ -9,6 +9,7 @@ import { ETAPES_TYPES, EtapeTypeId } from 'camino-common/src/static/etapesTypes.
 import { EtapeStatutId } from 'camino-common/src/static/etapesStatuts.js'
 import { getProductionOr } from './dgtm.queries.js'
 import type { Pool } from 'pg'
+import { isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools.js'
 
 const anneeDepartStats = 2015
 
@@ -236,9 +237,9 @@ export const getDGTMStatsInside =
 
     const producteursOr = await getProductionOr(pool)
 
-    if (producteursOr && producteursOr?.length) {
+    if (isNotNullNorUndefinedNorEmpty(producteursOr)) {
       result.producteursOr = producteursOr.reduce<Record<CaminoAnnee, number>>((acc, r) => {
-        if (r.annee && r.count) {
+        if (isNotNullNorUndefinedNorEmpty(r.annee) && r.count) {
           acc[toCaminoAnnee(r.annee)] = r.count
         }
 

--- a/packages/api/src/api/rest/statistiques/granulats-marins.ts
+++ b/packages/api/src/api/rest/statistiques/granulats-marins.ts
@@ -18,6 +18,7 @@ const statistiquesGranulatsMarinsActivitesFind = (titresActivites: ITitreActivit
       if (ta.activiteStatutId === ACTIVITES_STATUTS_IDS.DEPOSE) acc.activitesDeposesQuantiteCount++
 
       props.forEach(prop => {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (ta.contenu && ta.contenu.renseignementsProduction && ta.contenu.renseignementsProduction[prop]) {
           const value = ta.contenu!.renseignementsProduction[prop]
           acc[prop] += Math.abs(Number(value))

--- a/packages/api/src/api/rest/statistiques/metaux-metropole.ts
+++ b/packages/api/src/api/rest/statistiques/metaux-metropole.ts
@@ -314,6 +314,7 @@ const fiscaliteDetail = async (pool: Pool): Promise<FiscaliteParSubstanceParAnne
       ;(body.articles[categorie][substanceFiscaleToInput(substanceFiscale)] ??= {})[annee] = fromUniteFiscaleToUnite(substanceFiscale.uniteId, row[substance])
     })
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!body.titres[categorie]) {
       body.titres[categorie] = {
         commune_principale_exploitation: {},

--- a/packages/api/src/api/rest/titre-heritage.ts
+++ b/packages/api/src/api/rest/titre-heritage.ts
@@ -1,4 +1,5 @@
 import { DemarcheEtape } from 'camino-common/src/demarche.js'
+import { ETAPE_IS_NOT_BROUILLON } from 'camino-common/src/etape'
 import { isFondamentalesStatutOk } from 'camino-common/src/static/etapesStatuts.js'
 import { isEtapeTypeIdFondamentale } from 'camino-common/src/static/etapesTypes.js'
 import { TitrePropTitreEtapeFindDemarche } from 'camino-common/src/titres.js'
@@ -11,7 +12,7 @@ export const getMostRecentEtapeFondamentaleValide = <F extends Pick<DemarcheEtap
   for (const titreDemarche of titreDemarchesDesc) {
     const titreEtapeDesc = [...titreDemarche.etapes].sort((a, b) => b.ordre - a.ordre)
     for (const titreEtape of titreEtapeDesc) {
-      if (isEtapeTypeIdFondamentale(titreEtape.etape_type_id) && isFondamentalesStatutOk(titreEtape.etape_statut_id) && !titreEtape.is_brouillon) {
+      if (isEtapeTypeIdFondamentale(titreEtape.etape_type_id) && isFondamentalesStatutOk(titreEtape.etape_statut_id) && titreEtape.is_brouillon === ETAPE_IS_NOT_BROUILLON) {
         return titreEtape
       }
     }

--- a/packages/api/src/business/_logs-update.ts
+++ b/packages/api/src/business/_logs-update.ts
@@ -1,3 +1,4 @@
+import { isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools.js'
 import { Index, IEntrepriseEtablissement, IEntreprise } from '../types.js'
 
 export const logsUpdate = ({
@@ -47,82 +48,82 @@ export const logsUpdate = ({
   console.info('-')
   console.info('tâches exécutées:')
 
-  if (titresEtapesStatusUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresEtapesStatusUpdated)) {
     console.info(`mise à jour: ${titresEtapesStatusUpdated.length} étape(s) (statut)`)
   }
-  if (titresEtapesOrdreUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresEtapesOrdreUpdated)) {
     console.info(`mise à jour: ${titresEtapesOrdreUpdated.length} étape(s) (ordre)`)
   }
 
-  if (titresEtapesHeritagePropsUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresEtapesHeritagePropsUpdated)) {
     console.info(`mise à jour: ${titresEtapesHeritagePropsUpdated.length} étape(s) (héritage des propriétés)`)
   }
 
-  if (titresEtapesHeritageContenuUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresEtapesHeritageContenuUpdated)) {
     console.info(`mise à jour: ${titresEtapesHeritageContenuUpdated.length} étape(s) (héritage du contenu)`)
   }
 
-  if (titresDemarchesStatutUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresDemarchesStatutUpdated)) {
     console.info(`mise à jour: ${titresDemarchesStatutUpdated.length} démarche(s) (statut)`)
   }
 
-  if (titresDemarchesPublicUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresDemarchesPublicUpdated)) {
     console.info(`mise à jour: ${titresDemarchesPublicUpdated.length} démarche(s) (publicité)`)
   }
 
-  if (titresDemarchesOrdreUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresDemarchesOrdreUpdated)) {
     console.info(`mise à jour: ${titresDemarchesOrdreUpdated.length} démarche(s) (ordre)`)
   }
 
-  if (titresStatutIdUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresStatutIdUpdated)) {
     console.info(`mise à jour: ${titresStatutIdUpdated.length} titre(s) (statuts)`)
   }
 
-  if (titresPublicUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresPublicUpdated)) {
     console.info(`mise à jour: ${titresPublicUpdated.length} titre(s) (publicité)`)
   }
 
-  if (titresDemarchesDatesUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresDemarchesDatesUpdated)) {
     console.info(`mise à jour: ${titresDemarchesDatesUpdated.length} titre(s) (phases mises à jour)`)
   }
 
-  if (titresEtapesAdministrationsLocalesUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresEtapesAdministrationsLocalesUpdated)) {
     console.info(`mise à jour: ${titresEtapesAdministrationsLocalesUpdated.length} administration(s) locale(s) modifiée(s) dans des étapes`)
   }
 
-  if (titresPropsEtapesIdsUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresPropsEtapesIdsUpdated)) {
     console.info(`mise à jour: ${titresPropsEtapesIdsUpdated.length} titres(s) (propriétés-étapes)`)
   }
 
-  if (titresActivitesCreated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresActivitesCreated)) {
     console.info(`mise à jour: ${titresActivitesCreated.length} activité(s) créée(s)`)
   }
 
-  if (titresActivitesRelanceSent?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresActivitesRelanceSent)) {
     console.info(`mise à jour: ${titresActivitesRelanceSent.length} activité(s) relancée(s)`)
   }
 
-  if (titresActivitesStatutIdsUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresActivitesStatutIdsUpdated)) {
     console.info(`mise à jour: ${titresActivitesStatutIdsUpdated.length} activité(s) fermée(s)`)
   }
 
-  if (titresActivitesPropsUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(titresActivitesPropsUpdated)) {
     console.info(`mise à jour: ${titresActivitesPropsUpdated.length} activité(s) (propriété suppression)`)
   }
 
-  if (titresUpdatedIndex && Object.keys(titresUpdatedIndex).length) {
+  if (isNotNullNorUndefined(titresUpdatedIndex) && Object.keys(titresUpdatedIndex).length) {
     console.info(`mise à jour: ${Object.keys(titresUpdatedIndex).length} titre(s) (slugs)`)
   }
 
-  if (entreprisesUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(entreprisesUpdated)) {
     console.info(`mise à jour: ${entreprisesUpdated.length} adresse(s) d'entreprise(s)`)
   }
 
-  if (etablissementsUpdated?.length) {
+  if (isNotNullNorUndefinedNorEmpty(etablissementsUpdated)) {
     console.info(`mise à jour: ${etablissementsUpdated.length} établissement(s) d'entreprise(s)`)
   }
 
-  if (etablissementsDeleted?.length) {
+  if (isNotNullNorUndefinedNorEmpty(etablissementsDeleted)) {
     console.info(`suppression: ${etablissementsDeleted.length} établissement(s) d'entreprise(s)`)
   }
 }

--- a/packages/api/src/business/entreprises-guyane.ts
+++ b/packages/api/src/business/entreprises-guyane.ts
@@ -3,6 +3,7 @@ import { PAYS_IDS } from 'camino-common/src/static/pays.js'
 import { Regions } from 'camino-common/src/static/region.js'
 import { knex } from '../knex.js'
 import { exploitantsGuyaneSubscriberUpdate } from '../tools/api-mailjet/newsletter.js'
+import { isNullOrUndefined } from 'camino-common/src/typescript-tools.js'
 
 interface Result {
   id: string
@@ -31,7 +32,7 @@ export const subscribeUsersToGuyaneExploitants = async (): Promise<ResultAggrega
   const reduced = result
     .filter(({ codePostal }) => codePostal !== null && Regions[Departements[toDepartementId(codePostal)].regionId].paysId === PAYS_IDS['Département de la Guyane'])
     .reduce<Record<string, ResultAggregated>>((acc, user) => {
-      if (!acc[user.id]) {
+      if (isNullOrUndefined(acc[user.id])) {
         acc[user.id] = {
           email: user.email,
           entreprises: [user.nomEntreprise],

--- a/packages/api/src/business/processes/entreprises-update.ts
+++ b/packages/api/src/business/processes/entreprises-update.ts
@@ -6,10 +6,11 @@ import { entreprisesEtablissementsUpsert, entreprisesEtablissementsDelete, entre
 import { apiInseeEntreprisesEtablissementsGet, apiInseeEntreprisesGet } from '../../tools/api-insee/index.js'
 import { userSuper } from '../../database/user-super.js'
 import { Siren, sirenValidator } from 'camino-common/src/entreprise.js'
+import { isNotNullNorUndefined, isNullOrUndefinedOrEmpty } from 'camino-common/src/typescript-tools.js'
 
 const entreprisesEtablissementsToUpdateBuild = (entreprisesEtablissementsOld: IEntrepriseEtablissement[], entreprisesEtablissementsNew: IEntrepriseEtablissement[]) =>
   entreprisesEtablissementsNew.reduce((acc: IEntrepriseEtablissement[], entrepriseEtablissementNew) => {
-    const entrepriseEtablissementOld = entreprisesEtablissementsOld.find(a => a && a.id === entrepriseEtablissementNew.id)
+    const entrepriseEtablissementOld = entreprisesEtablissementsOld.find(a => isNotNullNorUndefined(a) && a.id === entrepriseEtablissementNew.id)
 
     const updated = !entrepriseEtablissementOld || objectsDiffer(entrepriseEtablissementNew, entrepriseEtablissementOld)
 
@@ -22,7 +23,7 @@ const entreprisesEtablissementsToUpdateBuild = (entreprisesEtablissementsOld: IE
 
 const entreprisesEtablissementsToDeleteBuild = (entreprisesEtablissementsOld: IEntrepriseEtablissement[], entreprisesEtablissementsNew: IEntrepriseEtablissement[]) =>
   entreprisesEtablissementsOld.reduce((acc: string[], entrepriseEtablissementOld) => {
-    const deleted = !entreprisesEtablissementsNew.find(a => a && a.id === entrepriseEtablissementOld.id)
+    const deleted = !entreprisesEtablissementsNew.find(a => isNotNullNorUndefined(a) && a.id === entrepriseEtablissementOld.id)
 
     if (deleted) {
       acc.push(entrepriseEtablissementOld.id)
@@ -48,7 +49,7 @@ const sirensFind = (entreprisesOld: IEntreprise[]): Siren[] =>
   Object.keys(
     entreprisesOld.reduce<{ [id in string]?: number }>((acc, entrepriseOld) => {
       const oldSiren = entrepriseOld.legalSiren
-      if (!oldSiren) return acc
+      if (isNullOrUndefinedOrEmpty(oldSiren)) return acc
 
       const numberFound = acc[oldSiren] ?? 0
       acc[oldSiren] = numberFound + 1

--- a/packages/api/src/business/processes/titres-demarches-depot-create.ts
+++ b/packages/api/src/business/processes/titres-demarches-depot-create.ts
@@ -15,6 +15,7 @@ import { getTitreTypeType } from 'camino-common/src/static/titresTypes.js'
 import { TitresTypesTypes } from 'camino-common/src/static/titresTypesTypes.js'
 import { NonEmptyArray, isNonEmptyArray, isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty, isNullOrUndefined } from 'camino-common/src/typescript-tools.js'
 import { getEntreprise, getEntrepriseUtilisateurs } from '../../api/rest/entreprises.queries.js'
+import { ETAPE_IS_NOT_BROUILLON } from 'camino-common/src/etape.js'
 
 const emailConfirmationDepotSend = async (
   emails: string[],
@@ -55,7 +56,7 @@ export const titreDemarcheDepotCheck = (titreDemarche: ITitreDemarche): boolean 
   if (!demarcheDefinition) return false
   if (titreDemarche.titre!.typeId === 'arm' && titreDemarche.typeId === 'oct') {
     // Si on a pas de demande faite
-    if (!titreDemarche.etapes?.find(e => e.typeId === 'mfr' && !e.isBrouillon)) {
+    if (!titreDemarche.etapes?.find(e => e.typeId === 'mfr' && e.isBrouillon === ETAPE_IS_NOT_BROUILLON)) {
       return false
     }
 

--- a/packages/api/src/business/processes/titres-slugs-update.test.ts
+++ b/packages/api/src/business/processes/titres-slugs-update.test.ts
@@ -5,6 +5,7 @@ import { titreSlugAndRelationsUpdate } from '../utils/titre-slug-and-relations-u
 import { titresGet } from '../../database/queries/titres.js'
 import { vi, describe, expect, test } from 'vitest'
 import { titreSlugValidator } from 'camino-common/src/validators/titres.js'
+import { isNotNullNorUndefined } from 'camino-common/src/typescript-tools.js'
 vi.mock('../utils/titre-slug-and-relations-update', () => ({
   __esModule: true,
   titreSlugAndRelationsUpdate: vi.fn(),
@@ -36,7 +37,7 @@ describe("mise à jour du slug d'un titre", () => {
     })
 
     const titresUpdatedIndex = await titresSlugsUpdate()
-    const titreSlug = titresUpdatedIndex && Object.keys(titresUpdatedIndex)[0]
+    const titreSlug = isNotNullNorUndefined(titresUpdatedIndex) && Object.keys(titresUpdatedIndex)[0]
 
     expect(titreSlug).toEqual(slug)
 

--- a/packages/api/src/business/rules-demarches/machine-common.test.ts
+++ b/packages/api/src/business/rules-demarches/machine-common.test.ts
@@ -74,6 +74,7 @@ describe('toMachineEtapes', () => {
           id: 'id',
           typeId: 'iii',
           statutId: 'fai',
+          isBrouillon: ETAPE_IS_NOT_BROUILLON,
           date: '2022-01-01',
         } as unknown as TitreEtapeForMachine,
       ])
@@ -87,9 +88,10 @@ describe('toMachineEtapes', () => {
           id: 'id',
           typeId: 'mfr',
           statutId: 'ffi',
+          isBrouillon: ETAPE_IS_NOT_BROUILLON,
           date: '2022-01-01',
         } as unknown as TitreEtapeForMachine,
       ])
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: le status ffi est inconnu, {"id":"id","typeId":"mfr","statutId":"ffi","date":"2022-01-01"}]`)
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: le status ffi est inconnu, {"id":"id","typeId":"mfr","statutId":"ffi","isBrouillon":false,"date":"2022-01-01"}]`)
   })
 })

--- a/packages/api/src/business/rules-demarches/machine-common.ts
+++ b/packages/api/src/business/rules-demarches/machine-common.ts
@@ -10,7 +10,7 @@ import { Regions } from 'camino-common/src/static/region.js'
 import { PaysId } from 'camino-common/src/static/pays.js'
 import { communeIdValidator } from 'camino-common/src/static/communes.js'
 import { z } from 'zod'
-import { etapeBrouillonValidator, etapeIdValidator } from 'camino-common/src/etape.js'
+import { ETAPE_IS_NOT_BROUILLON, etapeBrouillonValidator, etapeIdValidator } from 'camino-common/src/etape.js'
 import { isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools.js'
 import { km2Validator } from 'camino-common/src/number.js'
 export interface Etape {
@@ -47,7 +47,7 @@ export const toMachineEtapes = (etapes: (Pick<Partial<TitreEtapeForMachine>, 'or
   // TODO 2022-10-12 si on appelle titreEtapesSortAscByOrdre on se retrouve avec une grosse dépendance cyclique
   return etapes
     .slice()
-    .filter(dbEtape => !dbEtape.isBrouillon)
+    .filter(dbEtape => dbEtape.isBrouillon === ETAPE_IS_NOT_BROUILLON)
     .sort((a, b) => a.ordre! - b.ordre!)
     .map(dbEtape => toMachineEtape(dbEtape))
 }

--- a/packages/api/src/business/rules/titre-date-demande-find.ts
+++ b/packages/api/src/business/rules/titre-date-demande-find.ts
@@ -1,3 +1,4 @@
+import { isNullOrUndefined, isNullOrUndefinedOrEmpty } from 'camino-common/src/typescript-tools.js'
 import { ITitreDemarche } from '../../types.js'
 
 import { titreDemarcheSortAsc } from '../utils/titre-elements-sort-asc.js'
@@ -26,7 +27,7 @@ export const titreDateDemandeFind = (titreDemarches: ITitreDemarche[]) => {
   // - il n'y a pas d'étape de dépôt ou d'enregistrement de la demande
   // - l'étape n'a pas de date
   // alors retourne null
-  if (!titreEtape || !titreEtape.date) return null
+  if (isNullOrUndefined(titreEtape) || isNullOrUndefinedOrEmpty(titreEtape.date)) return null
 
   // sinon
   // retourne la date de l'étape

--- a/packages/api/src/business/rules/titre-demarche-statut-id-find.test.ts
+++ b/packages/api/src/business/rules/titre-demarche-statut-id-find.test.ts
@@ -7,13 +7,14 @@ import { toCaminoDate } from 'camino-common/src/date.js'
 import { describe, expect, test } from 'vitest'
 import { EtapeStatutId } from 'camino-common/src/static/etapesStatuts.js'
 import { TitreEtapeForMachine } from '../rules-demarches/machine-common.js'
-import { ETAPE_IS_BROUILLON } from 'camino-common/src/etape.js'
+import { ETAPE_IS_BROUILLON, ETAPE_IS_NOT_BROUILLON } from 'camino-common/src/etape.js'
 import { EtapeTypeId } from 'camino-common/src/static/etapesTypes.js'
 const etapesBuild = (etapesProps: Partial<ITitreEtape>[]): TitreEtapeForMachine[] =>
   etapesProps.map(
     (etapeProps, i) =>
       ({
         ...etapeProps,
+        isBrouillon: etapeProps.isBrouillon ?? ETAPE_IS_NOT_BROUILLON,
         ordre: i + 1,
       }) as unknown as TitreEtapeForMachine
   )

--- a/packages/api/src/business/rules/titre-phases-find.test.ts
+++ b/packages/api/src/business/rules/titre-phases-find.test.ts
@@ -1919,18 +1919,15 @@ describe("phases d'une démarche", () => {
       }
     `)
   })
+  // pour regénérer le fichier titre-phases-find.cas.json: `npm run test:generate-phase-data -w packages/api`
+  test.each(titresProd as TitrePhasesTest[])('cas réel N°%#', (titreTypeId, demarches) => {
+    const expectedResult = demarches.reduce<Record<DemarcheId, { dateDebut: CaminoDate | null | undefined; dateFin: CaminoDate | null | undefined }>>((acc, d) => {
+      if (d.demarcheDateDebut || d.demarcheDateFin) {
+        acc[d.id] = { dateDebut: d.demarcheDateDebut, dateFin: d.demarcheDateFin }
+      }
 
-  test('cas réels', () => {
-    const phasesReels = titresProd as TitrePhasesTest[]
-    phasesReels.forEach(([titreTypeId, demarches], index) => {
-      const expectedResult = demarches.reduce<Record<DemarcheId, { dateDebut: CaminoDate | null | undefined; dateFin: CaminoDate | null | undefined }>>((acc, d) => {
-        if (d.demarcheDateDebut || d.demarcheDateFin) {
-          acc[d.id] = { dateDebut: d.demarcheDateDebut, dateFin: d.demarcheDateFin }
-        }
-
-        return acc
-      }, {})
-      expect(titrePhasesFind(demarches, titreTypeId), `test N*${index}`).toStrictEqual(expectedResult)
-    })
+      return acc
+    }, {})
+    expect(titrePhasesFind(demarches, titreTypeId)).toStrictEqual(expectedResult)
   })
 })

--- a/packages/api/src/business/rules/titre-phases-find.ts
+++ b/packages/api/src/business/rules/titre-phases-find.ts
@@ -12,6 +12,7 @@ import { ETAPES_STATUTS } from 'camino-common/src/static/etapesStatuts.js'
 import { isDemarcheStatutNonStatue } from 'camino-common/src/static/demarchesStatuts.js'
 import { ETAPES_TYPES, EtapeTypeId } from 'camino-common/src/static/etapesTypes.js'
 import { isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty, isNullOrUndefinedOrEmpty } from 'camino-common/src/typescript-tools.js'
+import { ETAPE_IS_NOT_BROUILLON } from 'camino-common/src/etape.js'
 const DATE_PAR_DEFAUT_TITRE_INFINI = toCaminoDate('2018-12-31')
 /**
  * trouve une démarche acceptée ou terminée qui est
@@ -66,7 +67,7 @@ type Phase = { dateDebut: CaminoDate; dateFin: CaminoDate | null }
 type IntermediateTitrePhase = Phase & { demarcheId: DemarcheId; dateDeFinParDefaut?: true }
 export const titrePhasesFind = (titreDemarches: TitreDemarchePhaseFind[], titreTypeId: TitreTypeId): { [key in DemarcheId]?: Phase } => {
   const sortedDemarches = titreDemarcheSortAsc(titreDemarches).map(demarche => {
-    return { ...demarche, etapes: demarche.etapes?.filter(({ isBrouillon }) => !isBrouillon) }
+    return { ...demarche, etapes: demarche.etapes?.filter(({ isBrouillon }) => isBrouillon === ETAPE_IS_NOT_BROUILLON) }
   })
 
   const titreDemarcheAnnulation = titreDemarcheAnnulationFind(titreDemarches)

--- a/packages/api/src/business/rules/titre-prop-etape-find.ts
+++ b/packages/api/src/business/rules/titre-prop-etape-find.ts
@@ -14,6 +14,7 @@ import { titreEtapesSortDescByOrdre } from '../utils/titre-etapes-sort.js'
 import { isEtapeDecision } from 'camino-common/src/static/etapesTypes.js'
 import { isNotNullNorUndefined, isNullOrUndefined } from 'camino-common/src/typescript-tools.js'
 import { ETAPES_STATUTS } from 'camino-common/src/static/etapesStatuts.js'
+import { ETAPE_IS_BROUILLON } from 'camino-common/src/etape.js'
 
 const etapeAmodiataireFind = (date: CaminoDate, titreEtape: ITitreEtape, titreDemarches: Pick<ITitreDemarche, 'demarcheDateDebut' | 'demarcheDateFin' | 'id'>[]) => {
   const titreDemarche = titreDemarches.find(td => td.id === titreEtape.titreDemarcheId)
@@ -37,7 +38,7 @@ const etapeValideCheck = (titreEtape: ITitreEtape, titreDemarcheTypeId: Demarche
     return true
   }
 
-  if (titreEtape.isBrouillon) {
+  if (titreEtape.isBrouillon === ETAPE_IS_BROUILLON) {
     return false
   }
 

--- a/packages/api/src/business/utils/titre-elements-sort-asc.ts
+++ b/packages/api/src/business/utils/titre-elements-sort-asc.ts
@@ -10,10 +10,13 @@ export const titreDemarcheSortAsc = <T extends TitreDemarcheSortAscMinimalDemarc
     const aHasEtapes = a.etapes && a.etapes.length
     const bHasEtapes = b.etapes && b.etapes.length
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!aHasEtapes && bHasEtapes) return 1
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (aHasEtapes && !bHasEtapes) return -1
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!aHasEtapes && !bHasEtapes) {
       const aType = DemarchesTypes[a.typeId]
       const bType = DemarchesTypes[b.typeId]

--- a/packages/api/src/business/utils/titre-etape-heritage-contenu-find.ts
+++ b/packages/api/src/business/utils/titre-etape-heritage-contenu-find.ts
@@ -10,8 +10,10 @@ export const heritageContenuFind = (
   prevTitreEtape?: Pick<ITitreEtape, 'id' | 'contenu' | 'heritageContenu'> | null
 ) => {
   let hasChanged = false
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   let value = (titreEtape.contenu && titreEtape.contenu[sectionId] && titreEtape.contenu[sectionId][elementId]) as IContenuValeur
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   let heritage = titreEtape.heritageContenu && titreEtape.heritageContenu[sectionId] ? titreEtape.heritageContenu[sectionId][elementId] : null
   if (!heritage) {
     // l’héritage peut ne pas exister dans le cas où un nouvel élément d’une section a été ajouté via les métas
@@ -30,6 +32,7 @@ export const heritageContenuFind = (
   if (heritage.actif) {
     if (prevTitreEtape) {
       const oldValue = value
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       value = (prevTitreEtape.contenu && prevTitreEtape.contenu[sectionId] && prevTitreEtape.contenu[sectionId][elementId]) as IContenuValeur
 
       if ((oldValue !== undefined || value !== null) && (oldValue !== null || value !== undefined) && oldValue !== value) {
@@ -67,16 +70,19 @@ export const titreEtapeHeritageContenuFind = (
           const { hasChanged: contenuHasChanged, actif, value, etapeId } = heritageContenuFind(section.id, element.id, titreEtape, prevTitreEtape)
 
           if (contenuHasChanged) {
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (value || value === 0 || value === false) {
               if (!contenu) {
                 contenu = {}
               }
 
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               if (!contenu[section.id]) {
                 contenu[section.id] = {}
               }
 
               contenu![section.id][element.id] = value
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             } else if (contenu && contenu[section.id]) {
               delete contenu[section.id][element.id]
             }
@@ -85,6 +91,7 @@ export const titreEtapeHeritageContenuFind = (
               heritageContenu = {}
             }
 
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (!heritageContenu[section.id]) {
               heritageContenu[section.id] = {}
             }

--- a/packages/api/src/business/validations/titre-demarche-updation-validate.ts
+++ b/packages/api/src/business/validations/titre-demarche-updation-validate.ts
@@ -1,9 +1,10 @@
+import { isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools.js'
 import { ITitreDemarche } from '../../types.js'
 
 export const titreDemarcheUpdationValidate = async (titreDemarcheNew: ITitreDemarche, titreDemarcheOld: ITitreDemarche) => {
   const errors = [] as string[]
 
-  if (titreDemarcheNew.typeId !== titreDemarcheOld.typeId && titreDemarcheOld.etapes?.length) {
+  if (titreDemarcheNew.typeId !== titreDemarcheOld.typeId && isNotNullNorUndefinedNorEmpty(titreDemarcheOld.etapes)) {
     errors.push('impossible de modifier le type d’une démarche si celle-ci a déjà une ou plusieurs étapes')
   }
 

--- a/packages/api/src/database/models/_format/titre-etape-heritage.ts
+++ b/packages/api/src/database/models/_format/titre-etape-heritage.ts
@@ -23,6 +23,7 @@ export const heritagePropsFormat = async (heritageProps: IHeritageProps) => {
 export const heritageContenuFormat = async (heritageContenu: IHeritageContenu) => {
   const fields: FieldsEtape = { id: {} }
   for (const sectionId of Object.keys(heritageContenu)) {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (heritageContenu[sectionId]) {
       for (const elementId of Object.keys(heritageContenu[sectionId])) {
         if (heritageContenu[sectionId][elementId].etapeId) {

--- a/packages/api/src/database/queries/graph/build.ts
+++ b/packages/api/src/database/queries/graph/build.ts
@@ -20,6 +20,7 @@ const fieldsToArray = (fields: IFields, format: IFieldsFormat) => {
     const fieldsSubString = fieldsToString(fieldsSub, id, format)
 
     // ajoute un modifieur à certaines propriétés (p.e.: orderAsc)
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (fieldsSub.$modifier) {
       id = `${id}(${fieldsSub.$modifier})`
     }

--- a/packages/api/src/database/queries/titres-demarches.ts
+++ b/packages/api/src/database/queries/titres-demarches.ts
@@ -14,13 +14,14 @@ import { titresFiltersQueryModify } from './_titres-filters.js'
 import TitresEtapes from '../models/titres-etapes.js'
 import { User } from 'camino-common/src/roles'
 import { sortedDemarchesTypes } from 'camino-common/src/static/demarchesTypes.js'
+import { isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools.js'
 
 const etapesIncluesExcluesBuild = (q: QueryBuilder<TitresDemarches, TitresDemarches[]>, etapes: ITitreEtapeFiltre[], mode: 'etapesInclues' | 'etapesExclues') => {
   const raw = etapes
     .map(({ statutId, dateDebut, dateFin }) => {
-      const statutCond = statutId ? 'and etapes.statut_id = ?' : ''
-      const dateDebutCond = dateDebut ? 'and etapes.date >= ?' : ''
-      const dateFinCond = dateFin ? 'and etapes.date <= ?' : ''
+      const statutCond = isNotNullNorUndefinedNorEmpty(statutId) ? 'and etapes.statut_id = ?' : ''
+      const dateDebutCond = isNotNullNorUndefinedNorEmpty(dateDebut) ? 'and etapes.date >= ?' : ''
+      const dateFinCond = isNotNullNorUndefinedNorEmpty(dateFin) ? 'and etapes.date <= ?' : ''
 
       const condition = mode === 'etapesInclues' ? '> 0' : '= 0'
 
@@ -33,13 +34,13 @@ const etapesIncluesExcluesBuild = (q: QueryBuilder<TitresDemarches, TitresDemarc
     etapes.flatMap(({ typeId, statutId, dateDebut, dateFin }) => {
       const values = [typeId]
 
-      if (statutId) {
+      if (isNotNullNorUndefinedNorEmpty(statutId)) {
         values.push(statutId)
       }
-      if (dateDebut) {
+      if (isNotNullNorUndefinedNorEmpty(dateDebut)) {
         values.push(dateDebut)
       }
-      if (dateFin) {
+      if (isNotNullNorUndefinedNorEmpty(dateFin)) {
         values.push(dateFin)
       }
 
@@ -84,22 +85,22 @@ const titresDemarchesFiltersQueryModify = (
     q.whereIn('titresDemarches.id', titresDemarchesIds)
   }
 
-  if (typesIds?.length) {
+  if (isNotNullNorUndefinedNorEmpty(typesIds)) {
     q.whereIn('titresDemarches.typeId', typesIds)
   }
 
-  if (statutsIds?.length) {
+  if (isNotNullNorUndefinedNorEmpty(statutsIds)) {
     q.whereIn('titresDemarches.statutId', statutsIds)
   }
 
-  if (etapesInclues?.length || etapesExclues?.length) {
+  if (isNotNullNorUndefinedNorEmpty(etapesInclues) || isNotNullNorUndefinedNorEmpty(etapesExclues)) {
     q.leftJoinRelated('etapes').groupBy('titresDemarches.id')
 
-    if (etapesInclues?.length) {
+    if (isNotNullNorUndefinedNorEmpty(etapesInclues)) {
       etapesIncluesExcluesBuild(q, etapesInclues, 'etapesInclues')
     }
 
-    if (etapesExclues?.length) {
+    if (isNotNullNorUndefinedNorEmpty(etapesExclues)) {
       etapesIncluesExcluesBuild(q, etapesExclues, 'etapesExclues')
     }
   }
@@ -267,19 +268,20 @@ export const titresDemarchesGet = async (
   )
 
   if (colonne) {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!titresDemarchesColonnes[colonne]) {
       throw new Error(`Colonne « ${colonne} » inconnue`)
     }
 
     const groupBy = titresDemarchesColonnes[colonne].groupBy as string[]
 
-    if (titresDemarchesColonnes[colonne].relation) {
+    if (isNotNullNorUndefinedNorEmpty(titresDemarchesColonnes[colonne].relation)) {
       q.leftJoinRelated(titresDemarchesColonnes[colonne].relation!)
     }
     q.orderBy(titresDemarchesColonnes[colonne].id, ordre || 'asc')
     q.groupBy('titresDemarches.id')
 
-    if (groupBy) {
+    if (isNotNullNorUndefinedNorEmpty(groupBy)) {
       groupBy.forEach(gb => {
         q.groupBy(gb as string)
       })
@@ -290,11 +292,11 @@ export const titresDemarchesGet = async (
     q.orderBy('titresDemarches.ordre')
   }
 
-  if (page && intervalle) {
+  if (isNotNullNorUndefined(page) && page > 0 && isNotNullNorUndefined(intervalle) && intervalle > 0) {
     q.offset((page - 1) * intervalle)
   }
 
-  if (intervalle) {
+  if (isNotNullNorUndefined(intervalle) && intervalle > 0) {
     q.limit(intervalle)
   }
 

--- a/packages/api/src/database/queries/utilisateurs.ts
+++ b/packages/api/src/database/queries/utilisateurs.ts
@@ -11,9 +11,10 @@ import Utilisateurs from '../models/utilisateurs.js'
 import { utilisateursQueryModify } from './permissions/utilisateurs.js'
 import UtilisateursTitres from '../models/utilisateurs--titres.js'
 import { Role, User } from 'camino-common/src/roles.js'
+import { isNotNullNorUndefined, isNotNullNorUndefinedNorEmpty, isNullOrUndefined } from 'camino-common/src/typescript-tools.js'
 
 const userGet = async (userId?: string): Promise<User> => {
-  if (!userId) return null
+  if (isNullOrUndefined(userId)) return null
 
   const user = await Utilisateurs.query().withGraphFetched('[entreprises]').findById(userId)
   if (user) {
@@ -79,7 +80,7 @@ const utilisateursFiltersQueryModify = (
     q.whereIn('entreprises.id', entreprisesIds).leftJoinRelated('entreprises')
   }
 
-  if (noms && noms !== '') {
+  if (isNotNullNorUndefinedNorEmpty(noms)) {
     const nomsArray = stringSplit(noms)
     const fields = ['nom', 'prenom']
 
@@ -92,7 +93,7 @@ const utilisateursFiltersQueryModify = (
     })
   }
 
-  if (emails && emails !== '') {
+  if (isNotNullNorUndefinedNorEmpty(emails)) {
     q.where(b => {
       b.whereRaw(`LOWER(??) LIKE LOWER(?)`, ['utilisateurs.email', `%${emails}%`])
     })
@@ -101,8 +102,8 @@ const utilisateursFiltersQueryModify = (
   return q
 }
 
-const userByEmailGet = async (email: string | null | undefined) => {
-  if (email) {
+const userByEmailGet = async (email: string | null | undefined): Promise<Utilisateurs | undefined> => {
+  if (isNotNullNorUndefinedNorEmpty(email)) {
     const user: IUtilisateur | undefined = await Utilisateurs.query().withGraphFetched('[entreprises]').where('utilisateurs.email', email).first()
 
     if (user) {
@@ -122,8 +123,8 @@ const userByEmailGet = async (email: string | null | undefined) => {
   return undefined
 }
 
-export const userByKeycloakIdGet = async (keycloakId: string | null | undefined) => {
-  if (keycloakId) {
+export const userByKeycloakIdGet = async (keycloakId: string | null | undefined): Promise<IUtilisateur | undefined> => {
+  if (isNotNullNorUndefinedNorEmpty(keycloakId)) {
     const user: IUtilisateur | undefined = await Utilisateurs.query().withGraphFetched('[entreprises]').where('utilisateurs.keycloakId', keycloakId).first()
 
     if (user) {
@@ -205,11 +206,11 @@ const utilisateursGet = async (
     q.orderBy('utilisateurs.nom', 'asc')
   }
 
-  if (page && intervalle) {
+  if (isNotNullNorUndefined(page) && page > 0 && isNotNullNorUndefined(intervalle) && intervalle > 0) {
     q.offset((page - 1) * intervalle)
   }
 
-  if (intervalle) {
+  if (isNotNullNorUndefined(intervalle) && intervalle > 0) {
     q.limit(intervalle)
   }
 

--- a/packages/api/src/knex/migrations/20230605080141_refactor-communes-forets.ts
+++ b/packages/api/src/knex/migrations/20230605080141_refactor-communes-forets.ts
@@ -8,6 +8,7 @@ export const up = async (knex: Knex) => {
   const forets = await knex.select().from('titres_forets')
 
   const foretsByTitreEtapes = forets.reduce((acc, foret) => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!acc[foret.titreEtapeId]) {
       acc[foret.titreEtapeId] = []
     }
@@ -25,6 +26,7 @@ export const up = async (knex: Knex) => {
   const communes = await knex.select().from('titres_communes')
 
   const communesByTitreEtapes = communes.reduce((acc, commune) => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!acc[commune.titreEtapeId]) {
       acc[commune.titreEtapeId] = []
     }

--- a/packages/api/src/tools/api-insee/format.ts
+++ b/packages/api/src/tools/api-insee/format.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import { IApiSirenEtablissement, IApiSirenUniteLegalePeriode, IApiSirenUnionUniteLegalePeriodeEtablissmentUnite, IApiSirenUnionUniteLegaleEtablissmentUnite, IApiSirenUniteLegale } from './types.js'
 import { IEntrepriseEtablissement, IEntreprise } from '../../types.js'
 
@@ -12,7 +13,7 @@ import { entrepriseIdValidator } from 'camino-common/src/entreprise.js'
 interface IApiSirenNomFormat extends IApiSirenUnionUniteLegalePeriodeEtablissmentUnite, IApiSirenUnionUniteLegaleEtablissmentUnite {}
 
 const nomIndividuFormat = (nomUniteLegale: string, prenomUsuelUniteLegale?: string | null, sexeUniteLegale?: 'F' | 'M' | null) =>
-  `${sexeUniteLegale === 'F' ? 'MADAME' : 'MONSIEUR'} ${prenomUsuelUniteLegale || ''} ${nomUniteLegale}`
+  `${sexeUniteLegale === 'F' ? 'MADAME' : 'MONSIEUR'} ${prenomUsuelUniteLegale ?? ''} ${nomUniteLegale}`
 
 const nomEntrepriseFormat = (denominationUniteLegale?: string | null, denominationUsuelle1UniteLegale?: string | null, sigleUniteLegale?: string | null) => {
   const denomination = denominationUniteLegale && denominationUniteLegale.trim()
@@ -82,7 +83,7 @@ export const entrepriseEtablissementsFormat = (uniteLegale: IApiSirenUniteLegale
   return entrepriseEtablissements
 }
 
-export const entrepriseFormat = ({ uniteLegale, adresseEtablissement: adresse, siren }: IApiSirenEtablissement) => {
+export const entrepriseFormat = ({ uniteLegale, adresseEtablissement: adresse, siren }: IApiSirenEtablissement): IEntreprise => {
   const id = entrepriseIdValidator.parse(`fr-${siren}`)
 
   const entreprise = {

--- a/packages/api/src/tools/index.ts
+++ b/packages/api/src/tools/index.ts
@@ -9,16 +9,19 @@ export const equalStringArrays = (arr1: string[], arr2: string[]): boolean =>
   })
 
 export const dupFind = (key: string, ...arrays: Index<any>[][]) =>
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   arrays.reduce((result: Index<any>[], array) => result.filter(el => array.find(e => e[key] && e[key] === el[key])), arrays.pop() as Index<any>[])
 
 export const objectsDiffer = (a: Index<any> | any, b: Index<any> | any): boolean => {
   const comparator = (a: Index<any> | any, b: Index<any> | any) =>
     Object.keys(a).find(k => {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (a[k] && b[k]) {
         if (Array.isArray(a[k]) && Array.isArray(b[k])) {
           return a[k].find((ak: any, i: number) => objectsDiffer(ak, b[k][i]))
         }
 
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (typeof a[k] === 'object' && typeof b[k] === 'object' && a[k]) {
           return objectsDiffer(a[k], b[k])
         }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -52,7 +52,7 @@
       "default-param-last": 0,
       "no-unused-vars": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
-      "@typescript-eslint/explicit-module-boundary-types": 0,
+      "@typescript-eslint/explicit-module-boundary-types": "error",
       "@typescript-eslint/no-empty-interface": 0,
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/no-non-null-assertion": 0,

--- a/packages/common/src/date.ts
+++ b/packages/common/src/date.ts
@@ -8,7 +8,7 @@ const datesDiffInDays = (a: Date, b: Date) => {
   return Math.floor((utc2 - utc1) / (1000 * 60 * 60 * 24))
 }
 
-export const daysBetween = (a: CaminoDate, b: CaminoDate) => {
+export const daysBetween = (a: CaminoDate, b: CaminoDate): number => {
   return datesDiffInDays(new Date(a), new Date(b))
 }
 
@@ -58,8 +58,8 @@ export const dateFormat = (date: CaminoDate | null | undefined): CaminoDateForma
   return isNullOrUndefinedOrEmpty(date) ? ('' as CaminoDateFormated) : (`${date.substring(8)}-${date.substring(5, 7)}-${date.substring(0, 4)}` as CaminoDateFormated)
 }
 
-export const getCurrent = () => toCaminoDate(new Date())
-export const getCurrentAnnee = () => getAnnee(getCurrent())
+export const getCurrent = (): CaminoDate => toCaminoDate(new Date())
+export const getCurrentAnnee = (): CaminoAnnee => getAnnee(getCurrent())
 
 export const isAnnee = (annee: string): annee is CaminoAnnee => {
   return caminoAnneeValidator.safeParse(annee).success

--- a/packages/common/src/etape.ts
+++ b/packages/common/src/etape.ts
@@ -153,7 +153,7 @@ export type DocumentComplementaireAslEtapeDocumentModification = z.infer<typeof 
 export const etapeNoteValidator = z.object({ valeur: z.string(), is_avertissement: z.boolean() })
 export type EtapeNote = z.infer<typeof etapeNoteValidator>
 
-export const getStatutId = (etape: Pick<DeepReadonly<FlattenEtape>, 'date' | 'contenu' | 'typeId' | 'statutId'>, currentDate: CaminoDate) => {
+export const getStatutId = (etape: Pick<DeepReadonly<FlattenEtape>, 'date' | 'contenu' | 'typeId' | 'statutId'>, currentDate: CaminoDate): EtapeStatutId => {
   if (etape.typeId !== ETAPES_TYPES.participationDuPublic) {
     return etape.statutId
   }

--- a/packages/common/src/fiscalite.ts
+++ b/packages/common/src/fiscalite.ts
@@ -6,7 +6,7 @@ import { getDomaineId } from './static/titresTypes.js'
 import { Decimal } from 'decimal.js'
 import type { Fiscalite } from './validators/fiscalite.js'
 
-export const montantNetTaxeAurifere = (fiscalite: Fiscalite) => ('guyane' in fiscalite ? fiscalite.guyane.taxeAurifere : 0)
+export const montantNetTaxeAurifere = (fiscalite: Fiscalite): number => ('guyane' in fiscalite ? fiscalite.guyane.taxeAurifere : 0)
 
 export const fraisGestion = (fiscalite: Fiscalite): Decimal =>
   new Decimal(fiscalite.redevanceDepartementale).add(fiscalite.redevanceCommunale).add(montantNetTaxeAurifere(fiscalite)).mul(0.08).toDecimalPlaces(2)

--- a/packages/common/src/number.ts
+++ b/packages/common/src/number.ts
@@ -34,7 +34,7 @@ export const toDegresMinutes = (value: number): { degres: number; minutes: numbe
 }
 
 export const km2Validator = z.number().nonnegative().brand('CAMINO_KM2')
-export const createM2Validator = (v: ZodNumber) => v.transform(value => parseInt(`${value}`)).brand('CAMINO_M2')
+export const createM2Validator = (v: ZodNumber): z.ZodBranded<z.ZodEffects<z.ZodNumber, number, number>, 'CAMINO_M2'> => v.transform(value => parseInt(`${value}`)).brand('CAMINO_M2')
 export const m2Validator = createM2Validator(z.number())
 
 export const ZERO_KM2 = km2Validator.parse(0)

--- a/packages/common/src/permissions/activites.ts
+++ b/packages/common/src/permissions/activites.ts
@@ -12,12 +12,12 @@ import { ElementWithValue } from '../sections.js'
 import { isNonEmptyArray, isNullOrUndefined, memoize, NonEmptyArray, SimplePromiseFn } from '../typescript-tools.js'
 import { sectionsWithValueCompleteValidate } from './sections.js'
 
-export const canReadActivites = (user: User) =>
+export const canReadActivites = (user: User): boolean =>
   isSuper(user) ||
   isEntreprise(user) ||
   (isAdministration(user) && [ADMINISTRATION_TYPE_IDS.MINISTERE, ADMINISTRATION_TYPE_IDS.DREAL, ADMINISTRATION_TYPE_IDS.PREFECTURE].includes(Administrations[user.administrationId].typeId))
 
-export const canDeleteActiviteDocument = (activiteDocumentTypeId: ActiviteDocumentTypeId, activiteTypeId: ActivitesTypesId, activiteStatutId: ActivitesStatutId) => {
+export const canDeleteActiviteDocument = (activiteDocumentTypeId: ActiviteDocumentTypeId, activiteTypeId: ActivitesTypesId, activiteStatutId: ActivitesStatutId): boolean => {
   const documentType = activitesTypesDocumentsTypes[activiteTypeId]
   if (isNullOrUndefined(documentType) || documentType.optionnel || documentType.documentTypeId !== activiteDocumentTypeId) {
     return true

--- a/packages/common/src/permissions/administrations.ts
+++ b/packages/common/src/permissions/administrations.ts
@@ -3,7 +3,7 @@ import { AdministrationId, Administrations, sortedAdministrations } from '../sta
 import { Departements } from '../static/departement.js'
 import { DeepReadonly } from '../typescript-tools.js'
 
-export const canReadActivitesTypesEmails = (user: User, administrationId: AdministrationId) => {
+export const canReadActivitesTypesEmails = (user: User, administrationId: AdministrationId): boolean => {
   if (!canReadAdministrations(user)) {
     return false
   }
@@ -32,7 +32,7 @@ export const canReadActivitesTypesEmails = (user: User, administrationId: Admini
   return false
 }
 
-export const canReadAdministrations = (user: DeepReadonly<User>) => isSuper(user) || isAdministration(user)
+export const canReadAdministrations = (user: DeepReadonly<User>): boolean => isSuper(user) || isAdministration(user)
 
 export const canEditEmails = (user: User, administrationId: AdministrationId): boolean => {
   if (isSuper(user) || ((isAdministrationAdmin(user) || isAdministrationEditeur(user)) && Administrations[user.administrationId].typeId === 'min')) {

--- a/packages/common/src/permissions/journaux.ts
+++ b/packages/common/src/permissions/journaux.ts
@@ -1,3 +1,3 @@
 import { isSuper, User } from '../roles.js'
 
-export const canReadJournaux = (user: User) => isSuper(user)
+export const canReadJournaux = (user: User): boolean => isSuper(user)

--- a/packages/common/src/permissions/metas.ts
+++ b/packages/common/src/permissions/metas.ts
@@ -1,3 +1,3 @@
 import { isSuper, User } from '../roles.js'
 
-export const canReadMetas = (user: User) => isSuper(user)
+export const canReadMetas = (user: User): boolean => isSuper(user)

--- a/packages/common/src/permissions/utilisateurs.ts
+++ b/packages/common/src/permissions/utilisateurs.ts
@@ -1,17 +1,17 @@
 import { isSuper, isAdministrationAdmin, isAdministrationEditeur, User, isAdministration, isEntreprise, isBureauDEtudes, ROLES, Role, UserNotNull } from '../roles.js'
 
 export const canCreateEntreprise = (user: User): boolean => isSuper(user) || isAdministrationAdmin(user) || isAdministrationEditeur(user)
-export const canReadUtilisateurs = (user: User) => isSuper(user) || isAdministration(user) || isEntreprise(user) || isBureauDEtudes(user)
+export const canReadUtilisateurs = (user: User): boolean => isSuper(user) || isAdministration(user) || isEntreprise(user) || isBureauDEtudes(user)
 
-export const canReadUtilisateur = (user: User, id: string) => user?.id === id || canReadUtilisateurs(user)
-export const canDeleteUtilisateur = (user: User, id: string) => {
+export const canReadUtilisateur = (user: User, id: string): boolean => user?.id === id || canReadUtilisateurs(user)
+export const canDeleteUtilisateur = (user: User, id: string): boolean => {
   if (isSuper(user)) {
     return true
   }
 
   return user?.id === id
 }
-export const canEditPermission = (user: User, utilisateur: UserNotNull) => {
+export const canEditPermission = (user: User, utilisateur: UserNotNull): boolean => {
   if (user?.id === utilisateur.id) {
     return false
   }

--- a/packages/common/src/rest.ts
+++ b/packages/common/src/rest.ts
@@ -282,7 +282,7 @@ export type PutRestRoutes = CaminoRestRouteList<typeof IDS, 'put'>[number]
 
 export type CaminoRestParams<Route extends CaminoRestRoute> = z.infer<(typeof CaminoRestRoutes)[Route]['params']>
 
-export const getRestRoute = <T extends CaminoRestRoute>(path: T, params: CaminoRestParams<T>, searchParams: Record<string, string | string[]> = {}) => {
+export const getRestRoute = <T extends CaminoRestRoute>(path: T, params: CaminoRestParams<T>, searchParams: Record<string, string | string[]> = {}): string => {
   const urlParams = new URLSearchParams()
   Object.keys(searchParams).forEach(key => {
     const params = searchParams[key]

--- a/packages/common/src/static/communes.ts
+++ b/packages/common/src/static/communes.ts
@@ -4,7 +4,7 @@ export const communeIdValidator = z.string().brand('Communes')
 
 export type CommuneId = z.infer<typeof communeIdValidator>
 
-export const toCommuneId = (value: string) => communeIdValidator.parse(value)
+export const toCommuneId = (value: string): CommuneId => communeIdValidator.parse(value)
 
 export const communeValidator = z.object({ id: communeIdValidator, nom: z.string() })
 export type Commune = z.infer<typeof communeValidator>

--- a/packages/common/src/static/etapesTypes.ts
+++ b/packages/common/src/static/etapesTypes.ts
@@ -1504,5 +1504,5 @@ const ETAPES_DECISIONS_IDS = [
 
 const ETAPES_BROUILLONS_IDS = [ETAPES_TYPES.demande, ETAPES_TYPES.avisDesServicesEtCommissionsConsultatives, ETAPES_TYPES.participationDuPublic] as const satisfies Readonly<EtapeTypeId[]>
 
-export const isEtapeDecision = (etapeTypeId: EtapeTypeId): EtapeBrouillon => ETAPES_DECISIONS_IDS.includes(etapeTypeId) as EtapeBrouillon
+export const isEtapeDecision = (etapeTypeId: EtapeTypeId): boolean => ETAPES_DECISIONS_IDS.includes(etapeTypeId)
 export const canBeBrouillon = (etapeTypeId: EtapeTypeId): EtapeBrouillon => ETAPES_BROUILLONS_IDS.includes(etapeTypeId) as EtapeBrouillon

--- a/packages/common/src/static/titresStatuts.ts
+++ b/packages/common/src/static/titresStatuts.ts
@@ -57,4 +57,4 @@ export const isTitreStatutId = (value: string): value is TitreStatutId => TITRES
 
 export const titresStatutsArray = Object.values(TitresStatuts)
 
-export const isTitreValide = (titreStatutId: TitreStatutId) => [TitresStatutIds.Valide, TitresStatutIds.ModificationEnInstance, TitresStatutIds.SurvieProvisoire].includes(titreStatutId)
+export const isTitreValide = (titreStatutId: TitreStatutId): boolean => [TitresStatutIds.Valide, TitresStatutIds.ModificationEnInstance, TitresStatutIds.SurvieProvisoire].includes(titreStatutId)

--- a/packages/common/src/static/titresTypes_demarchesTypes_etapesTypes/sdom.ts
+++ b/packages/common/src/static/titresTypes_demarchesTypes_etapesTypes/sdom.ts
@@ -1,14 +1,15 @@
 import { DeepReadonly } from '../../typescript-tools.js'
 import { DEMARCHES_TYPES_IDS } from '../demarchesTypes.js'
-import { DocumentTypeId, DOCUMENTS_TYPES_IDS } from '../documentsTypes.js'
+import { DOCUMENTS_TYPES_IDS } from '../documentsTypes.js'
 import { DOMAINES_IDS } from '../domaines.js'
 import { ETAPES_TYPES } from '../etapesTypes.js'
 import { SDOMZoneId, SDOMZoneIds } from '../sdom.js'
 import { toTitreTypeId } from '../titresTypes.js'
 import { TITRES_TYPES_TYPES_IDS } from '../titresTypesTypes.js'
 
-export const documentTypeIdsBySdomZonesGet = (sdomZones: DeepReadonly<SDOMZoneId[]>, titreTypeId: string, demarcheTypeId: string, etapeTypeId: string) => {
-  const documentTypeIds: DocumentTypeId[] = []
+type DocumentTypeIdsBySdomZonesGet = 'nir' | 'jeg' | 'nip'
+export const documentTypeIdsBySdomZonesGet = (sdomZones: DeepReadonly<SDOMZoneId[]>, titreTypeId: string, demarcheTypeId: string, etapeTypeId: string): DocumentTypeIdsBySdomZonesGet[] => {
+  const documentTypeIds: DocumentTypeIdsBySdomZonesGet[] = []
 
   // Pour les demandes d’octroi d’AXM
   if (

--- a/packages/common/src/typescript-tools.ts
+++ b/packages/common/src/typescript-tools.ts
@@ -10,7 +10,7 @@ export function isNotNullNorUndefined<T>(value: T | null | undefined): value is 
 export function isNotNullNorUndefinedNorEmpty<U>(value: DeepReadonly<U[]> | null | undefined): value is DeepReadonly<NonEmptyArray<U>>
 export function isNotNullNorUndefinedNorEmpty<U>(value: U[] | null | undefined): value is NonEmptyArray<U>
 export function isNotNullNorUndefinedNorEmpty(value: string | null | undefined): value is string
-export function isNotNullNorUndefinedNorEmpty(value: string | DeepReadonly<any[]> | null | undefined) {
+export function isNotNullNorUndefinedNorEmpty(value: string | DeepReadonly<any[]> | null | undefined): boolean {
   if (Array.isArray(value)) {
     if (!isNullOrUndefined(value)) {
       return isNonEmptyArray(value)
@@ -25,7 +25,7 @@ export function isNotNullNorUndefinedNorEmpty(value: string | DeepReadonly<any[]
 export function isNullOrUndefinedOrEmpty<U>(value: DeepReadonly<U[]> | null | undefined): value is null | undefined
 export function isNullOrUndefinedOrEmpty<U>(value: U[] | null | undefined): value is null | undefined
 export function isNullOrUndefinedOrEmpty(value: string | null | undefined): value is null | undefined
-export function isNullOrUndefinedOrEmpty(value: string | DeepReadonly<any[]> | null | undefined) {
+export function isNullOrUndefinedOrEmpty(value: string | DeepReadonly<any[]> | null | undefined): boolean {
   if (value === null || value === undefined) {
     return true
   }
@@ -119,8 +119,8 @@ export const map = <T, U>(array: DeepReadonly<NonEmptyArray<T>>, transform: (ite
   return [transform(first), ...rest.map(transform)]
 }
 
-export const isTrue = <T extends true>(_t: T) => {}
-export const isFalse = <T extends false>(_t: T) => {}
+export const isTrue = <T extends true>(_t: T): void => {}
+export const isFalse = <T extends false>(_t: T): void => {}
 
 export type Expect<T, E> = T extends E ? (E extends T ? true : false) : false
 

--- a/packages/common/src/zod-tools.ts
+++ b/packages/common/src/zod-tools.ts
@@ -13,6 +13,7 @@ export const nullToDefault =
     return val
   }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const makeFlattenValidator = <T extends z.ZodTypeAny>(schema: T) =>
   z.object({
     value: schema,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -144,7 +144,7 @@
           "default-param-last": 0,
           "no-unused-vars": 0,
           "@typescript-eslint/explicit-function-return-type": 0,
-          "@typescript-eslint/explicit-module-boundary-types": 0,
+          "@typescript-eslint/explicit-module-boundary-types": "error",
           "@typescript-eslint/no-empty-interface": 0,
           "@typescript-eslint/no-explicit-any": 0,
           "@typescript-eslint/no-non-null-assertion": 0,

--- a/packages/ui/src/api/_client.js
+++ b/packages/ui/src/api/_client.js
@@ -57,7 +57,7 @@ const graphQLCall = async (url, query, variables, cacheKey = query.definitions[0
 
   return dataContent
 }
-
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const apiGraphQLFetch = (query, cacheKey) => async variables => {
   try {
     return await graphQLCall(apiUrl, query, variables, cacheKey)

--- a/packages/ui/src/components/_map/leaflet.ts
+++ b/packages/ui/src/components/_map/leaflet.ts
@@ -1,5 +1,5 @@
-import type { LatLngExpression, Icon, DivIcon, GeoJSONOptions, DivIconOptions, MarkerOptions } from 'leaflet'
-import type { GeoJsonObject, LineString } from 'geojson'
+import type { LatLngExpression, Icon, DivIcon, GeoJSONOptions, DivIconOptions, MarkerOptions, GeoJSON, Marker, LatLng, LatLngBounds } from 'leaflet'
+import type { GeoJsonObject, Geometry, LineString } from 'geojson'
 import 'leaflet.markercluster'
 import 'leaflet-gesture-handling'
 import 'leaflet-fullscreen'
@@ -21,11 +21,11 @@ L.Marker.prototype.options.icon = L.icon({
   shadowSize: [41, 41],
 })
 
-export const leafletMarkerBuild = (latLng: LatLngExpression, icon: Icon | DivIcon | undefined, options?: MarkerOptions | undefined) => L.marker(latLng, { icon, ...options })
+export const leafletMarkerBuild = (latLng: LatLngExpression, icon: Icon | DivIcon | undefined, options?: MarkerOptions | undefined): Marker<any> => L.marker(latLng, { icon, ...options })
 
-export const leafletGeojsonBuild = (geojson: GeoJsonObject | undefined, options?: GeoJSONOptions<any> | undefined) => L.geoJSON(geojson, options)
+export const leafletGeojsonBuild = (geojson: GeoJsonObject | undefined, options?: GeoJSONOptions<any> | undefined): GeoJSON<any, Geometry> => L.geoJSON(geojson, options)
 
-export const leafletGeojsonCenterFind = (geojson: GeoJsonObject | undefined) => L.geoJSON(geojson).getBounds().getCenter()
+export const leafletGeojsonCenterFind = (geojson: GeoJsonObject | undefined): LatLng => L.geoJSON(geojson).getBounds().getCenter()
 
-export const leafletDivIconBuild = (divIconOptions: DivIconOptions) => L.divIcon(divIconOptions)
-export const leafletGeojsonBoundsGet = (zone: LineString) => L.geoJSON(zone).getBounds()
+export const leafletDivIconBuild = (divIconOptions: DivIconOptions): DivIcon => L.divIcon(divIconOptions)
+export const leafletGeojsonBoundsGet = (zone: LineString): LatLngBounds => L.geoJSON(zone).getBounds()

--- a/packages/ui/src/components/_ui/dsfr-button.tsx
+++ b/packages/ui/src/components/_ui/dsfr-button.tsx
@@ -3,6 +3,7 @@ import { DsfrIcon } from './dsfrIconSpriteType'
 import { CaminoRouterLink } from '../../router/camino-router-link'
 import { isNotNullNorUndefined } from 'camino-common/src/typescript-tools'
 import { CaminoRouteNames, CaminoVueRoute } from '@/router/routes'
+import type { JSX } from 'vue/jsx-runtime'
 
 export const buttonTypes = ['primary', 'secondary', 'tertiary', 'tertiary-no-outline'] as const
 type ButtonType = (typeof buttonTypes)[number]
@@ -68,7 +69,7 @@ type DsfrLinkProps<T extends CaminoRouteNames> = {
   style?: HTMLAttributes['style']
   class?: HTMLAttributes['class']
 } & ({ to: CaminoVueRoute<T>; disabled: false } | { href: HTMLAnchorElement['href']; download?: HTMLAnchorElement['download']; target?: HTMLAnchorElement['target']; rel?: HTMLAnchorElement['rel'] })
-export const DsfrLink = <T extends CaminoRouteNames>(props: DsfrLinkProps<T>) => {
+export const DsfrLink = <T extends CaminoRouteNames>(props: DsfrLinkProps<T>): JSX.Element => {
   const iconClass = []
   if (props.icon !== null && props.label !== null) {
     iconClass.push(`fr-${props.buttonType ? 'btn' : 'link'}--icon-right`)

--- a/packages/ui/src/components/_ui/filters/filters-input.tsx
+++ b/packages/ui/src/components/_ui/filters/filters-input.tsx
@@ -1,6 +1,7 @@
 import { InputCaminoFiltres } from './camino-filtres'
 import { caminoFiltres } from 'camino-common/src/filters'
 import { DsfrInput } from '@/components/_ui/dsfr-input'
+import type { JSX } from 'vue/jsx-runtime'
 
 type Props = {
   filter: InputCaminoFiltres
@@ -8,7 +9,7 @@ type Props = {
   onFilterInput: (value: string) => void
 }
 
-export function FiltersInput(props: Props) {
+export function FiltersInput(props: Props): JSX.Element {
   const filter = caminoFiltres[props.filter]
 
   return <DsfrInput initialValue={props.initialValue} class="fr-mb-2w" type={{ type: 'text' }} legend={{ placeholder: filter.placeholder, main: filter.name }} valueChanged={props.onFilterInput} />

--- a/packages/ui/src/components/_ui/filters/filters.tsx
+++ b/packages/ui/src/components/_ui/filters/filters.tsx
@@ -72,7 +72,7 @@ const etapesLabelFormat = (filter: EtapeCaminoFiltres, values: FilterEtapeValue[
       }
     })
 }
-
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getInitialFiltres = (route: CaminoRouteLocation, filters: readonly CaminoFiltre[]) => {
   const allValues = {
     administrationTypesIds: caminoFiltres.administrationTypesIds.validator.parse(routerQueryToStringArray(route.query.administrationTypesIds)),

--- a/packages/ui/src/components/_ui/functional-loader.tsx
+++ b/packages/ui/src/components/_ui/functional-loader.tsx
@@ -8,7 +8,7 @@ type Props<T> = {
   renderItem: (item: T) => JSX.Element | null
 } & Pick<HTMLAttributes, 'class' | 'style'>
 
-export const LoadingElement = <T,>(props: Props<T>) => {
+export const LoadingElement = <T,>(props: Props<T>): JSX.Element => {
   return (
     <>
       {props.data.status === 'LOADED' ? (

--- a/packages/ui/src/components/_ui/label-with-value.tsx
+++ b/packages/ui/src/components/_ui/label-with-value.tsx
@@ -1,6 +1,6 @@
 import { capitalize } from 'camino-common/src/strings'
 import { HTMLAttributes, FunctionalComponent } from 'vue'
-import { JSX } from 'vue/jsx-runtime'
+import type { JSX } from 'vue/jsx-runtime'
 
 type ItemProp = {
   item: JSX.Element

--- a/packages/ui/src/components/_ui/table-pagination.tsx
+++ b/packages/ui/src/components/_ui/table-pagination.tsx
@@ -5,7 +5,7 @@ import { CaminoRouterLink, routerQueryToNumber } from '@/router/camino-router-li
 import { AsyncData } from '../../api/client-rest'
 import { LoadingElement } from './functional-loader'
 import { CaminoRouteLocation } from '@/router/routes'
-
+type Params<ColumnId> = { page: number; colonne: ColumnId; ordre: 'asc' | 'desc' }
 interface Props<ColumnId> {
   columns: readonly Column<ColumnId>[]
   data: AsyncData<{
@@ -14,10 +14,10 @@ interface Props<ColumnId> {
   }>
   route: CaminoRouteLocation
   caption: string
-  updateParams: (params: { page: number; colonne: ColumnId; ordre: 'asc' | 'desc' }) => void
+  updateParams: (params: Params<ColumnId>) => void
 }
 
-export const getInitialParams = <ColumnId extends string>(route: Pick<CaminoRouteLocation, 'query'>, columns: readonly Column<ColumnId>[]) => {
+export const getInitialParams = <ColumnId extends string>(route: Pick<CaminoRouteLocation, 'query'>, columns: readonly Column<ColumnId>[]): Params<ColumnId> => {
   return {
     colonne: getSortColumnFromRoute(route, columns),
     page: getPageNumberFromRoute(route),

--- a/packages/ui/src/components/_ui/tag.tsx
+++ b/packages/ui/src/components/_ui/tag.tsx
@@ -2,6 +2,7 @@ import { isNotNullNorUndefined } from 'camino-common/src/typescript-tools'
 import { HTMLAttributes } from 'vue'
 import { CaminoRouterLink } from '../../router/camino-router-link'
 import { CaminoRouteNames, CaminoVueRoute } from '@/router/routes'
+import type { JSX } from 'vue/jsx-runtime'
 
 export type DsfrTagProps<T extends CaminoRouteNames> = {
   ariaLabel: string
@@ -12,7 +13,7 @@ export type DsfrTagProps<T extends CaminoRouteNames> = {
   to?: CaminoVueRoute<T>
   onClicked?: () => void
 }
-export const DsfrTag = <T extends CaminoRouteNames>(props: DsfrTagProps<T>) => {
+export const DsfrTag = <T extends CaminoRouteNames>(props: DsfrTagProps<T>): JSX.Element => {
   const classes = ['fr-tag', `fr-tag--${props.tagSize ?? 'md'}`, props.class]
 
   const clicked = (e: MouseEvent) => {

--- a/packages/ui/src/components/etape/etape-avis-edit.stories.tsx
+++ b/packages/ui/src/components/etape/etape-avis-edit.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta = {
   title: 'Components/Etape/EtapeAvisEdit',
   // @ts-ignore
   component: EtapeAvisEdit,
-  decorators: [() => ({ template: '<div class="dsfr"><story/></div>' })],
+  decorators: [(): { template: string } => ({ template: '<div class="dsfr"><story/></div>' })],
 }
 export default meta
 

--- a/packages/ui/src/components/etape/heritage-edit.tsx
+++ b/packages/ui/src/components/etape/heritage-edit.tsx
@@ -29,7 +29,7 @@ type Props<T extends DeepReadonly<HeritagePossible>> = {
   updateHeritage: (update: NoInfer<T>) => void
 }
 
-export const HeritageEdit = <T extends DeepReadonly<HeritagePossible>>(props: Props<T>) => {
+export const HeritageEdit = <T extends DeepReadonly<HeritagePossible>>(props: Props<T>): JSX.Element => {
   const updateHeritage = () => {
     const etapeHeritee = props.prop.etapeHeritee
     const newHeritage = !props.prop.heritee

--- a/packages/ui/src/components/titres/mapUtil.ts
+++ b/packages/ui/src/components/titres/mapUtil.ts
@@ -130,7 +130,7 @@ export const zones = {
 const L = window.L
 
 export type CaminoMarkerClusterGroup = MarkerClusterGroup & { caminoDomaineId?: DomaineId }
-export const clustersBuild = () =>
+export const clustersBuild = (): { [key in DomaineId]?: CaminoMarkerClusterGroup } =>
   sortedDomaines.reduce<{ [key in DomaineId]?: CaminoMarkerClusterGroup }>((clusters, { id }) => {
     clusters[id] = L.markerClusterGroup({
       iconCreateFunction(cluster) {
@@ -198,7 +198,13 @@ const svgDomaineAnchor = (domaineId: DomaineId): string => {
 }
 
 export type LayerWithTitreId = Layer & { titreId: TitreId }
-export const layersBuild = (titres: TitreWithPerimetre[], router: Pick<CaminoRouter, 'push'>, entreprises: Entreprise[], markersAlreadyInMap: TitreId[] = [], geojsonAlreadyInMap: TitreId[] = []) => {
+export const layersBuild = (
+  titres: TitreWithPerimetre[],
+  router: Pick<CaminoRouter, 'push'>,
+  entreprises: Entreprise[],
+  markersAlreadyInMap: TitreId[] = [],
+  geojsonAlreadyInMap: TitreId[] = []
+): { geojsons: Record<TitreId, GeoJSON>; markers: CaminoMarker[] } => {
   const div = document.createElement('div')
   const titleName = document.createElement('div')
   const listeTitulaires = document.createElement('ul')

--- a/packages/ui/src/components/titres/table-utils.ts
+++ b/packages/ui/src/components/titres/table-utils.ts
@@ -129,7 +129,7 @@ export const statutCell = (titre: { titre_statut_id: TitreStatutId }): Component
   }
 }
 
-export const referencesCell = (titre: { references?: { nom: string; referenceTypeId: ReferenceTypeId }[] }) => {
+export const referencesCell = (titre: { references?: { nom: string; referenceTypeId: ReferenceTypeId }[] }): ComponentColumnData => {
   const references = titre.references?.map(ref => `${ReferencesTypes[ref.referenceTypeId].nom} : ${ref.nom}`)
 
   return {
@@ -142,7 +142,7 @@ export const referencesCell = (titre: { references?: { nom: string; referenceTyp
     value: references,
   }
 }
-export const titulairesCell = (titre: { titulaireIds?: EntrepriseId[] }, entreprisesIndex: Record<EntrepriseId, string>) => {
+export const titulairesCell = (titre: { titulaireIds?: EntrepriseId[] }, entreprisesIndex: Record<EntrepriseId, string>): ComponentColumnData => {
   return {
     component: markRaw(List),
     props: {
@@ -159,7 +159,7 @@ const domaineCell = (titre: { domaineId: DomaineId }) => ({
   value: titre.domaineId,
 })
 
-export const typeCell = (typeId: TitreTypeId) => {
+export const typeCell = (typeId: TitreTypeId): ComponentColumnData => {
   return {
     component: markRaw(TitreTypeTypeNom),
     props: { titreTypeId: typeId },

--- a/packages/ui/src/stats/matomo.ts
+++ b/packages/ui/src/stats/matomo.ts
@@ -1,7 +1,7 @@
 import { CaminoRouter } from '@/typings/vue-router'
 import { isNotNullNorUndefined, isNullOrUndefined } from 'camino-common/src/typescript-tools'
 
-export const initMatomo = async (options: { router: CaminoRouter; host: string; siteId: string; environnement: string }) => {
+export const initMatomo = async (options: { router: CaminoRouter; host: string; siteId: string; environnement: string }): Promise<void> => {
   const trackerFileName = 'piwik'
 
   await bootstrap(options.host, trackerFileName)

--- a/packages/ui/src/utils/debounce.ts
+++ b/packages/ui/src/utils/debounce.ts
@@ -1,7 +1,7 @@
 export const createDebounce = () => {
   let timeout: ReturnType<typeof setTimeout>
 
-  return function (fnc: () => void, delayMs = 500) {
+  return function (fnc: () => void, delayMs = 500): void {
     clearTimeout(timeout)
     timeout = setTimeout(() => {
       fnc()

--- a/packages/ui/src/utils/vue-tsx-utils.ts
+++ b/packages/ui/src/utils/vue-tsx-utils.ts
@@ -1,13 +1,13 @@
 import { DeepReadonly, readonly, ref, Ref } from 'vue'
 
-export const isEventWithTarget = (event: any): event is FocusEvent & { target: HTMLInputElement } => event.target
+export const isEventWithTarget = (event: Event): event is FocusEvent & { target: HTMLInputElement } => 'target' in event
 
 let seed = Math.random()
 // USED Only for testing
 export const setSeed = (value: number): void => {
   seed = value
 }
-export const random = () => {
+export const random = (): number => {
   const x = Math.sin(seed++) * 10000
 
   return x - Math.floor(x)


### PR DESCRIPTION
On s'est fait avoir sur un nouveau code, on a rajouté des warnings.

Il est temps d'en finir avec ces warnings


PS : J'ai au final réactivé la règle `explicit-module-boundary-types` qui remonte des erreurs (warns sur l'api) quand on ne type pas explicitement les retours des fonctions exportées (ça fait partie des tips and tricks de typescript pour les performances)