### PR TITLE
fix(style): aligne correctement le bouton à droite

### DIFF
--- a/packages/ui/src/components/_common/dsfr-perimetre.tsx
+++ b/packages/ui/src/components/_common/dsfr-perimetre.tsx
@@ -118,27 +118,27 @@ const TabCaminoMap = defineComponent<TabCaminoMapProps>(props => {
       <DemarcheMap perimetre={props.perimetre} titreTypeId={props.titreTypeId} style={{ minHeight: '400px' }} class="fr-mb-1w" maxMarkers={maxRows} neighbours={neighbours} />
       <div style={{ display: 'flex' }}>
         {isNotNullNorUndefined(props.perimetre.surface) ? <div class="fr-text--md">Surface : {props.perimetre.surface} Km²</div> : null}
-        {props.perimetre.geojson_origine_geo_systeme_id !== '4326' ? (
+        <div style={{ marginLeft: 'auto' }}>
+          {props.perimetre.geojson_origine_geo_systeme_id !== '4326' ? (
+            <DsfrLink
+              class="fr-mr-2w"
+              href={`data:${contentTypes.geojson};charset=utf-8,${encodeURI(JSON.stringify(geojson_origine.value))}`}
+              download={`perimetre-${props.titreSlug}-${props.perimetre.geojson_origine_geo_systeme_id}.geojson`}
+              icon="fr-icon-download-line"
+              buttonType="secondary"
+              title={`Télécharge le périmètre au format geojson dans le référentiel d'origine ${props.perimetre.geojson_origine_geo_systeme_id}`}
+              label={`.geojson (${props.perimetre.geojson_origine_geo_systeme_id})`}
+            />
+          ) : null}
           <DsfrLink
-            class="fr-mr-2w"
-            style={{ marginLeft: 'auto' }}
-            href={`data:${contentTypes.geojson};charset=utf-8,${encodeURI(JSON.stringify(geojson_origine.value))}`}
-            download={`perimetre-${props.titreSlug}-${props.perimetre.geojson_origine_geo_systeme_id}.geojson`}
+            href={`data:${contentTypes.geojson};charset=utf-8,${encodeURI(JSON.stringify(geojson_4326.value))}`}
+            download={`perimetre-${props.titreSlug}-4326.geojson`}
             icon="fr-icon-download-line"
             buttonType="secondary"
-            title={`Télécharge le périmètre au format geojson dans le référentiel d'origine ${props.perimetre.geojson_origine_geo_systeme_id}`}
-            label={`.geojson (${props.perimetre.geojson_origine_geo_systeme_id})`}
+            title="Télécharge le périmètre au format geojson dans le référentiel 4326"
+            label=".geojson (4326)"
           />
-        ) : null}
-        <DsfrLink
-          href={`data:${contentTypes.geojson};charset=utf-8,${encodeURI(JSON.stringify(geojson_4326.value))}`}
-          download={`perimetre-${props.titreSlug}-4326.geojson`}
-          style={{ marginLeft: 'auto' }}
-          icon="fr-icon-download-line"
-          buttonType="secondary"
-          title="Télécharge le périmètre au format geojson dans le référentiel 4326"
-          label=".geojson (4326)"
-        />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Les boutons de téléchargement sont alignés à droite.

Avant :
![Capture d’écran du 2024-07-23 15-43-59](https://github.com/user-attachments/assets/68d71204-e7a1-4a9a-a92f-9c0dd506ddf1)

Après :
![Capture d’écran du 2024-07-23 15-43-52](https://github.com/user-attachments/assets/997df4c1-d81d-423b-b0f9-9db9c63b2137)

