### PR TITLE
fix(démarche): corrige le calcul d'ordre quand on a une demande en brouillon

### DIFF
--- a/packages/api/src/business/utils/titre-etapes-sort.test.ts
+++ b/packages/api/src/business/utils/titre-etapes-sort.test.ts
@@ -385,4 +385,74 @@ describe('trie les étapes', () => {
     `)
     expect(result[result.length - 1].id).toBe('asc')
   })
+
+  test("une demande en brouillon à la même date qu'une décision de l'administration est en 1ère position", () => {
+    const etapes: TitreEtapeForMachine[] = [
+      {
+        id: newEtapeId('mfr'),
+        typeId: 'mfr',
+        date: toCaminoDate('2020-01-01'),
+        statutId: 'fai',
+        isBrouillon: ETAPE_IS_BROUILLON,
+        surface: null,
+        ordre: 1,
+        communes: [],
+        contenu: null,
+      },
+      {
+        id: newEtapeId('dex'),
+        typeId: 'dex',
+        date: toCaminoDate('2020-01-01'),
+        statutId: 'acc',
+        isBrouillon: ETAPE_IS_NOT_BROUILLON,
+        surface: null,
+        ordre: 3,
+        communes: [],
+        contenu: null,
+      },
+    ]
+    const result = titreEtapesSortAscByDate(etapes, newDemarcheId(), DEMARCHES_TYPES_IDS.Octroi, TITRES_TYPES_IDS.PERMIS_D_EXPLOITATION_GEOTHERMIE)
+
+    expect(result.map(({ id }) => id)).toMatchInlineSnapshot(`
+         [
+           "mfr",
+           "dex",
+         ]
+       `)
+  })
+
+  test("une demande en brouillon à une date postérieure qu'une décision de l'administration est en 2ème position", () => {
+    const etapes: TitreEtapeForMachine[] = [
+      {
+        id: newEtapeId('mfr'),
+        typeId: 'mfr',
+        date: toCaminoDate('2020-01-02'),
+        statutId: 'fai',
+        isBrouillon: ETAPE_IS_BROUILLON,
+        surface: null,
+        ordre: 1,
+        communes: [],
+        contenu: null,
+      },
+      {
+        id: newEtapeId('dex'),
+        typeId: 'dex',
+        date: toCaminoDate('2020-01-01'),
+        statutId: 'acc',
+        isBrouillon: ETAPE_IS_NOT_BROUILLON,
+        surface: null,
+        ordre: 3,
+        communes: [],
+        contenu: null,
+      },
+    ]
+    const result = titreEtapesSortAscByDate(etapes, newDemarcheId(), DEMARCHES_TYPES_IDS.Octroi, TITRES_TYPES_IDS.PERMIS_D_EXPLOITATION_GEOTHERMIE)
+
+    expect(result.map(({ id }) => id)).toMatchInlineSnapshot(`
+           [
+             "dex",
+             "mfr",
+           ]
+         `)
+  })
 })

--- a/packages/api/src/business/utils/titre-etapes-sort.ts
+++ b/packages/api/src/business/utils/titre-etapes-sort.ts
@@ -7,6 +7,7 @@ import { getEtapesTDE } from 'camino-common/src/static/titresTypes_demarchesType
 import { DemarcheId } from 'camino-common/src/demarche'
 import { isNotNullNorUndefinedNorEmpty } from 'camino-common/src/typescript-tools'
 import { ETAPE_IS_BROUILLON } from 'camino-common/src/etape'
+import { ETAPES_TYPES } from 'camino-common/src/static/etapesTypes'
 
 // classe les étapes selon leur ordre inverse: 3, 2, 1.
 export const titreEtapesSortDescByOrdre = <T extends Pick<ITitreEtape, 'ordre'>>(titreEtapes: T[]): T[] => titreEtapes.toSorted((a, b) => b.ordre! - a.ordre!)
@@ -36,6 +37,17 @@ export const titreEtapesSortAscByDate = <T extends TitreEtapeForMachine>(titreEt
     if (isNotNullNorUndefinedNorEmpty(etapesInBrouillon)) {
       return [...result, ...etapesInBrouillon].toSorted((a, b) => {
         if (a.isBrouillon === ETAPE_IS_BROUILLON || b.isBrouillon === ETAPE_IS_BROUILLON) {
+          // TODO 2024-08-05 si c'est une demande en brouillon à la même date qu'une autre étape, on la met en première position. On devrait pouvoir mieux faire via la machine et les étapes potentielles.
+          if (a.date === b.date) {
+            if (a.typeId === ETAPES_TYPES.demande) {
+              return -1
+            }
+
+            if (b.typeId === ETAPES_TYPES.demande) {
+              return 1
+            }
+          }
+
           return a.date.localeCompare(b.date)
         }
 


### PR DESCRIPTION
Corrige le pb avec https://camino.beta.gouv.fr/titres/g-px-epinay-sous-senart-1996?demarcheSlug=g-px-epinay-sous-senart-1996-oct01