### PR TITLE
chore(common): force la couverture de code a toujours être égale ou supérieure à la précédente

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,7 @@ else
 endif
 
 test/common:
-ifndef CI
 	npm run test -w packages/common
-else
-	npm run test -w packages/common -- --coverage
-endif
 
 test/api-unit:
 ifndef CI

--- a/knip.ts
+++ b/knip.ts
@@ -44,7 +44,7 @@ const config = {
     },
     "packages/common": {
       ignoreDependencies: [
-        "@vitest/coverage-v8",
+        "vite",
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
         "node",

--- a/packages/common/src/administrations.test.ts
+++ b/packages/common/src/administrations.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from 'vitest'
+import { getAdministrationsLocales } from './administrations'
+import { communeIdValidator } from './static/communes'
+
+test('getAdministrationsLocales', () => {
+  expect(getAdministrationsLocales([], [])).toStrictEqual([])
+  expect(() => getAdministrationsLocales(null, [])).toThrowErrorMatchingInlineSnapshot(`[Error: les communes ne sont pas chargées]`)
+  expect(getAdministrationsLocales([], ['Baie de Bourgneuf et littoral vendéen'])).toMatchInlineSnapshot(`
+    [
+      "dre-pays-de-la-loire-01",
+      "pre-44109-01",
+      "pre-85191-01",
+    ]
+  `)
+
+  expect(getAdministrationsLocales([communeIdValidator.parse('97300')], ['Baie de Bourgneuf et littoral vendéen'])).toMatchInlineSnapshot(`
+    [
+      "dea-guyane-01",
+      "dre-pays-de-la-loire-01",
+      "aut-mrae-guyane-01",
+      "ope-onf-973-01",
+      "pre-97302-01",
+      "pre-44109-01",
+      "pre-85191-01",
+    ]
+  `)
+})

--- a/packages/common/src/static/departement.test.ts
+++ b/packages/common/src/static/departement.test.ts
@@ -1,4 +1,4 @@
-import { communeIdValidator } from './communes'
+import { CommuneId, communeIdValidator } from './communes'
 import { checkCodePostal, isDepartementId, toDepartementId, departementsMetropole } from './departement'
 import { test, expect } from 'vitest'
 
@@ -13,6 +13,8 @@ test('toDepartementId', () => {
   expect(toDepartementId(checkCodePostal('71056'))).toBe('71')
   expect(toDepartementId(checkCodePostal('06093'))).toBe('06')
   expect(toDepartementId(communeIdValidator.parse('06093'))).toBe('06')
+
+  expect(() => toDepartementId('not a commune id' as CommuneId)).toThrowErrorMatchingInlineSnapshot(`[Error: impossible de trouver l'id de département dans le code postal not a commune id]`)
 })
 
 test('departementsMetropole', () => {

--- a/packages/common/src/static/phasesStatuts.test.ts
+++ b/packages/common/src/static/phasesStatuts.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from 'vitest'
+import { isDemarchePhaseValide } from './phasesStatuts'
+import { toCaminoDate } from '../date'
+
+test('isDemarchePhaseValide', () => {
+  expect(isDemarchePhaseValide(toCaminoDate('2022-01-01'), null)).toBe(false)
+  expect(isDemarchePhaseValide(toCaminoDate('2022-01-01'), { demarcheDateDebut: toCaminoDate('2021-01-01') })).toBe(true)
+  expect(isDemarchePhaseValide(toCaminoDate('2022-01-01'), { demarcheDateDebut: toCaminoDate('2021-01-01'), demarcheDateFin: toCaminoDate('2021-12-31') })).toBe(false)
+})

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -21,5 +21,6 @@
     "types": ["node"],
     "resolveJsonModule": true,
     "noEmit": true
-  }
+  },
+  "exclude": ["vitest.config.ts"]
 }

--- a/packages/common/vitest.config.ts
+++ b/packages/common/vitest.config.ts
@@ -1,0 +1,21 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      enabled: true,
+      extension: '.ts',
+      thresholds: {
+        // the endgame is to put thresholds at 100 and never touch it again :)
+        autoUpdate: true,
+        branches: 89.8,
+        functions: 79.52,
+        lines: 95.85,
+        statements: 95.85,
+        perFile: false,
+      },
+    },
+  },
+})


### PR DESCRIPTION
Pour le passage à gitlab, on s'est dit qu'on allait se débarrasser de codecov, que personne ne regarde :)

On teste uniquement sur le common de ne pas faire baisser la couverture
