### PR TITLE
refactor(api): on fait passer les paramètres dans un objet plutôt qu'à plat

### DIFF
--- a/packages/api/src/api/rest/administrations.ts
+++ b/packages/api/src/api/rest/administrations.ts
@@ -2,67 +2,70 @@ import { Request as JWTRequest } from 'express-jwt'
 import { HTTP_STATUS } from 'camino-common/src/http'
 
 import { CustomResponse } from './express-type'
-import { AdminUserNotNull, User, UserNotNull } from 'camino-common/src/roles'
+import { AdminUserNotNull, User } from 'camino-common/src/roles'
 import { Pool } from 'pg'
-import { AdministrationId, administrationIdValidator } from 'camino-common/src/static/administrations'
+import { administrationIdValidator } from 'camino-common/src/static/administrations'
 import { canReadAdministrations } from 'camino-common/src/permissions/administrations'
 import { deleteAdministrationActiviteTypeEmail, getActiviteTypeEmailsByAdministrationId, getUtilisateursByAdministrationId, insertAdministrationActiviteTypeEmail } from './administrations.queries'
 import { AdministrationActiviteTypeEmail } from 'camino-common/src/administrations'
 import { CaminoApiError } from '../../types'
 import { ZodUnparseable } from '../../tools/fp-tools'
-import { DeepReadonly } from 'camino-common/src/typescript-tools'
 import { DbQueryAccessError } from '../../pg-database'
 import { Effect, Match } from 'effect'
 import { RestNewPostCall } from '../../server/rest'
 
-export const getAdministrationUtilisateurs = (pool: Pool) => async (req: JWTRequest<User>, res: CustomResponse<AdminUserNotNull[]>) => {
-  const user = req.auth
+export const getAdministrationUtilisateurs =
+  (pool: Pool) =>
+  async (req: JWTRequest<User>, res: CustomResponse<AdminUserNotNull[]>): Promise<void> => {
+    const user = req.auth
 
-  const parsed = administrationIdValidator.safeParse(req.params.administrationId)
+    const parsed = administrationIdValidator.safeParse(req.params.administrationId)
 
-  if (!parsed.success) {
-    console.warn(`l'administrationId est obligatoire`)
-    res.sendStatus(HTTP_STATUS.FORBIDDEN)
-  } else if (!canReadAdministrations(user)) {
-    res.sendStatus(HTTP_STATUS.FORBIDDEN)
-  } else {
-    try {
-      res.json(await getUtilisateursByAdministrationId(pool, parsed.data))
-    } catch (e) {
-      console.error(e)
+    if (!parsed.success) {
+      console.warn(`l'administrationId est obligatoire`)
+      res.sendStatus(HTTP_STATUS.FORBIDDEN)
+    } else if (!canReadAdministrations(user)) {
+      res.sendStatus(HTTP_STATUS.FORBIDDEN)
+    } else {
+      try {
+        res.json(await getUtilisateursByAdministrationId(pool, parsed.data))
+      } catch (e) {
+        console.error(e)
 
-      res.sendStatus(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        res.sendStatus(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      }
     }
   }
-}
 
-export const getAdministrationActiviteTypeEmails = (pool: Pool) => async (req: JWTRequest<User>, res: CustomResponse<AdministrationActiviteTypeEmail[]>) => {
-  const user = req.auth
+export const getAdministrationActiviteTypeEmails =
+  (pool: Pool) =>
+  async (req: JWTRequest<User>, res: CustomResponse<AdministrationActiviteTypeEmail[]>): Promise<void> => {
+    const user = req.auth
 
-  const parsed = administrationIdValidator.safeParse(req.params.administrationId)
+    const parsed = administrationIdValidator.safeParse(req.params.administrationId)
 
-  if (!parsed.success) {
-    console.warn(`l'administrationId est obligatoire`)
-    res.sendStatus(HTTP_STATUS.FORBIDDEN)
-  } else if (!canReadAdministrations(user)) {
-    res.sendStatus(HTTP_STATUS.FORBIDDEN)
-  } else {
-    try {
-      res.json(await getActiviteTypeEmailsByAdministrationId(pool, parsed.data))
-    } catch (e) {
-      console.error(e)
+    if (!parsed.success) {
+      console.warn(`l'administrationId est obligatoire`)
+      res.sendStatus(HTTP_STATUS.FORBIDDEN)
+    } else if (!canReadAdministrations(user)) {
+      res.sendStatus(HTTP_STATUS.FORBIDDEN)
+    } else {
+      try {
+        res.json(await getActiviteTypeEmailsByAdministrationId(pool, parsed.data))
+      } catch (e) {
+        console.error(e)
 
-      res.sendStatus(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        res.sendStatus(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      }
     }
   }
-}
 
-export const addAdministrationActiviteTypeEmails: RestNewPostCall<'/rest/administrations/:administrationId/activiteTypeEmails'> = (
-  pool: Pool,
-  user: DeepReadonly<UserNotNull>,
-  body: DeepReadonly<AdministrationActiviteTypeEmail>,
-  params: { administrationId: AdministrationId }
-): Effect.Effect<boolean, CaminoApiError<'Accès interdit' | ZodUnparseable | DbQueryAccessError>> => {
+export const addAdministrationActiviteTypeEmails: RestNewPostCall<'/rest/administrations/:administrationId/activiteTypeEmails'> = ({
+  pool,
+  user,
+  body,
+  params,
+}): Effect.Effect<boolean, CaminoApiError<'Accès interdit' | ZodUnparseable | DbQueryAccessError>> => {
   return Effect.Do.pipe(
     Effect.filterOrFail(
       () => canReadAdministrations(user),
@@ -80,12 +83,12 @@ export const addAdministrationActiviteTypeEmails: RestNewPostCall<'/rest/adminis
   )
 }
 
-export const deleteAdministrationActiviteTypeEmails: RestNewPostCall<'/rest/administrations/:administrationId/activiteTypeEmails/delete'> = (
-  pool: Pool,
-  user: DeepReadonly<UserNotNull>,
-  body: DeepReadonly<AdministrationActiviteTypeEmail>,
-  params: { administrationId: AdministrationId }
-): Effect.Effect<boolean, CaminoApiError<'Accès interdit' | ZodUnparseable | DbQueryAccessError>> => {
+export const deleteAdministrationActiviteTypeEmails: RestNewPostCall<'/rest/administrations/:administrationId/activiteTypeEmails/delete'> = ({
+  pool,
+  user,
+  body,
+  params,
+}): Effect.Effect<boolean, CaminoApiError<'Accès interdit' | ZodUnparseable | DbQueryAccessError>> => {
   return Effect.Do.pipe(
     Effect.filterOrFail(
       () => canReadAdministrations(user),

--- a/packages/api/src/api/rest/demarches.ts
+++ b/packages/api/src/api/rest/demarches.ts
@@ -94,7 +94,7 @@ export const demarcheSupprimer =
     }
   }
 
-export const demarcheCreer: RestNewPostCall<'/rest/demarches'> = (pool, user, demarche): Effect.Effect<DemarcheCreationOutput, CaminoApiError<string>> => {
+export const demarcheCreer: RestNewPostCall<'/rest/demarches'> = ({ pool, user, body: demarche }): Effect.Effect<DemarcheCreationOutput, CaminoApiError<string>> => {
   return pipe(
     Effect.tryPromise({
       try: async () => {

--- a/packages/api/src/api/rest/perimetre.ts
+++ b/packages/api/src/api/rest/perimetre.ts
@@ -2,7 +2,7 @@ import { DemarcheId, demarcheIdOrSlugValidator } from 'camino-common/src/demarch
 import { CaminoRequest, CustomResponse } from './express-type'
 import { Pool } from 'pg'
 import { pipe, Effect, Match } from 'effect'
-import { GeoSystemeId, GeoSystemes } from 'camino-common/src/static/geoSystemes'
+import { GeoSystemes } from 'camino-common/src/static/geoSystemes'
 import { HTTP_STATUS } from 'camino-common/src/http'
 import {
   ConvertPointsErrors,
@@ -16,7 +16,7 @@ import {
 } from './perimetre.queries'
 import { TitreTypeId } from 'camino-common/src/static/titresTypes'
 import { getMostRecentEtapeFondamentaleValide } from './titre-heritage'
-import { isAdministrationAdmin, isAdministrationEditeur, isDefault, isSuper, User, UserNotNull } from 'camino-common/src/roles'
+import { isAdministrationAdmin, isAdministrationEditeur, isDefault, isSuper, User } from 'camino-common/src/roles'
 import { getDemarcheByIdOrSlug, getEtapesByDemarcheId } from './demarches.queries'
 import { getAdministrationsLocalesByTitreId, getTitreByIdOrSlug, getTitulairesAmodiatairesByTitreId } from './titres.queries'
 import { etapeIdOrSlugValidator } from 'camino-common/src/etape'
@@ -37,9 +37,6 @@ import {
   featureCollectionForagesValidator,
   FeatureCollectionForages,
   featureForagePropertiesValidator,
-  GeojsonImportPointsBody,
-  GeojsonImportBody,
-  GeojsonImportForagesBody,
 } from 'camino-common/src/perimetre'
 import { join } from 'node:path'
 import { readFileSync } from 'node:fs'
@@ -196,12 +193,12 @@ type GeojsonImportErrorMessages =
   | GetGeojsonByGeoSystemeIdErrorMessages
   | GetGeojsonInformationErrorMessages
   | ConvertPointsErrors
-export const geojsonImport: RestNewPostCall<'/rest/geojson/import/:geoSystemeId'> = (
-  pool: Pool,
-  user: DeepReadonly<UserNotNull>,
-  body: DeepReadonly<GeojsonImportBody>,
-  params: { geoSystemeId: GeoSystemeId }
-): Effect.Effect<DeepReadonly<GeojsonInformations>, CaminoApiError<GeojsonImportErrorMessages>> => {
+export const geojsonImport: RestNewPostCall<'/rest/geojson/import/:geoSystemeId'> = ({
+  pool,
+  user,
+  body,
+  params,
+}): Effect.Effect<DeepReadonly<GeojsonInformations>, CaminoApiError<GeojsonImportErrorMessages>> => {
   const pathFrom = join(process.cwd(), `/files/tmp/${body.tempDocumentName}`)
 
   return pipe(
@@ -452,12 +449,12 @@ const fileNameToCsv = (pathFrom: string): Effect.Effect<unknown[], CaminoError<t
 const accesInterditError = 'Accès interdit' as const
 type GeosjsonImportPointsErrorMessages = ZodUnparseable | DbQueryAccessError | typeof accesInterditError | 'Fichier incorrect' | ConvertPointsErrors
 
-export const geojsonImportPoints: RestNewPostCall<'/rest/geojson_points/import/:geoSystemeId'> = (
-  pool: Pool,
-  user: DeepReadonly<UserNotNull>,
-  geojsonImportInput: DeepReadonly<GeojsonImportPointsBody>,
-  params: { geoSystemeId: GeoSystemeId }
-): Effect.Effect<GeojsonImportPointsResponse, CaminoApiError<GeosjsonImportPointsErrorMessages>> => {
+export const geojsonImportPoints: RestNewPostCall<'/rest/geojson_points/import/:geoSystemeId'> = ({
+  pool,
+  user,
+  body: geojsonImportInput,
+  params,
+}): Effect.Effect<GeojsonImportPointsResponse, CaminoApiError<GeosjsonImportPointsErrorMessages>> => {
   return Effect.Do.pipe(
     Effect.filterOrFail(
       () => !isDefault(user),
@@ -500,12 +497,11 @@ export const geojsonImportPoints: RestNewPostCall<'/rest/geojson_points/import/:
 }
 
 type GeosjsonImportForagesErrorMessages = ZodUnparseable | DbQueryAccessError | typeof ouvertureCsvError | typeof ouvertureShapeError | typeof ouvertureGeoJSONError | ConvertPointsErrors
-export const geojsonImportForages: RestNewPostCall<'/rest/geojson_forages/import/:geoSystemeId'> = (
-  pool: Pool,
-  _user: DeepReadonly<UserNotNull>,
-  body: DeepReadonly<GeojsonImportForagesBody>,
-  params: { geoSystemeId: GeoSystemeId }
-): Effect.Effect<GeojsonImportForagesResponse, CaminoApiError<GeosjsonImportForagesErrorMessages>> => {
+export const geojsonImportForages: RestNewPostCall<'/rest/geojson_forages/import/:geoSystemeId'> = ({
+  pool,
+  body,
+  params,
+}): Effect.Effect<GeojsonImportForagesResponse, CaminoApiError<GeosjsonImportForagesErrorMessages>> => {
   const filename = body.tempDocumentName
 
   const pathFrom = join(process.cwd(), `/files/tmp/${filename}`)

--- a/packages/api/src/api/rest/titre-demande.ts
+++ b/packages/api/src/api/rest/titre-demande.ts
@@ -1,14 +1,13 @@
 import { titresGet } from '../../database/queries/titres'
 
 import { titreUpdateTask } from '../../business/titre-update'
-import { UserNotNull, isEntrepriseOrBureauDEtude } from 'camino-common/src/roles'
+import { isEntrepriseOrBureauDEtude } from 'camino-common/src/roles'
 import { linkTitres } from '../../database/queries/titres-titres.queries'
 import { canCreateTitre } from 'camino-common/src/permissions/titres'
 import { checkTitreLinks } from '../../business/validations/titre-links-validate'
-import { DeepReadonly, isNotNullNorUndefinedNorEmpty, isNullOrUndefined, isNullOrUndefinedOrEmpty } from 'camino-common/src/typescript-tools'
-import { createAutomaticallyEtapeWhenCreatingTitre, TitreDemande, TitreDemandeOutput } from 'camino-common/src/titres'
+import { isNotNullNorUndefinedNorEmpty, isNullOrUndefined, isNullOrUndefinedOrEmpty } from 'camino-common/src/typescript-tools'
+import { createAutomaticallyEtapeWhenCreatingTitre, TitreDemandeOutput } from 'camino-common/src/titres'
 import { HTTP_STATUS } from 'camino-common/src/http'
-import { Pool } from 'pg'
 import { ETAPE_IS_BROUILLON } from 'camino-common/src/etape'
 import { Effect, pipe, Match } from 'effect'
 import { capitalize } from 'effect/String'
@@ -36,12 +35,7 @@ type TitreDemandeCreerErrors =
   | "Problème lors de l'abonnement de l'utilisateur au titre"
   | "L'entreprise est obligatoire"
   | "L'entreprise ne doit pas être présente"
-export const titreDemandeCreer: RestNewPostCall<'/rest/titres'> = (
-  pool: Pool,
-  user: DeepReadonly<UserNotNull>,
-  titreDemande: DeepReadonly<TitreDemande>,
-  _params: {}
-): Effect.Effect<TitreDemandeOutput, CaminoApiError<TitreDemandeCreerErrors>> => {
+export const titreDemandeCreer: RestNewPostCall<'/rest/titres'> = ({ pool, user, body: titreDemande }): Effect.Effect<TitreDemandeOutput, CaminoApiError<TitreDemandeCreerErrors>> => {
   return Effect.Do.pipe(
     Effect.filterOrFail(
       () => canCreateTitre(user, titreDemande.titreTypeId),

--- a/packages/api/src/api/rest/utilisateurs.ts
+++ b/packages/api/src/api/rest/utilisateurs.ts
@@ -223,12 +223,9 @@ export const generateQgisToken =
     }
   }
 
-export const registerToNewsletter: RestNewGetCall<'/rest/utilisateurs/registerToNewsletter'> = (
-  _pool: Pool,
-  _user: DeepReadonly<User>,
-  _params: Record<string, never>,
-  searchParams: { email: string }
-): Effect.Effect<boolean, CaminoApiError<"Impossible de s'enregistrer à la newsletter">> => {
+export const registerToNewsletter: RestNewGetCall<'/rest/utilisateurs/registerToNewsletter'> = ({
+  searchParams,
+}): Effect.Effect<boolean, CaminoApiError<"Impossible de s'enregistrer à la newsletter">> => {
   return pipe(
     Effect.tryPromise({
       try: async () => {
@@ -286,7 +283,7 @@ export const utilisateurs =
 
 type GetUtilisateursError = DbQueryAccessError | ZodUnparseable | "Impossible d'accéder à la liste des utilisateurs" | 'droits insuffisants'
 
-export const getUtilisateurs: RestNewGetCall<'/rest/utilisateurs'> = (pool, user, _params, searchParams): Effect.Effect<DeepReadonly<UtilisateursTable>, CaminoApiError<GetUtilisateursError>> => {
+export const getUtilisateurs: RestNewGetCall<'/rest/utilisateurs'> = ({ pool, user, searchParams }): Effect.Effect<DeepReadonly<UtilisateursTable>, CaminoApiError<GetUtilisateursError>> => {
   return Effect.Do.pipe(
     Effect.flatMap(() => getUtilisateursFilteredAndSorted(pool, user, searchParams)),
     Effect.map(utilisateurs => {
@@ -307,7 +304,7 @@ export const getUtilisateurs: RestNewGetCall<'/rest/utilisateurs'> = (pool, user
 }
 
 type GetUtilisateurError = DbQueryAccessError | ZodUnparseable | 'droits insuffisants'
-export const getUtilisateur: RestNewGetCall<'/rest/utilisateurs/:id'> = (pool, user, params, _searchParams): Effect.Effect<DeepReadonly<UserNotNull>, CaminoApiError<GetUtilisateurError>> => {
+export const getUtilisateur: RestNewGetCall<'/rest/utilisateurs/:id'> = ({ pool, user, params }): Effect.Effect<DeepReadonly<UserNotNull>, CaminoApiError<GetUtilisateurError>> => {
   return Effect.Do.pipe(
     Effect.flatMap(() => newGetUtilisateurById(pool, params.id, user)),
     Effect.mapError(caminoError =>

--- a/packages/ui/src/components/etape/type-edit.tsx
+++ b/packages/ui/src/components/etape/type-edit.tsx
@@ -130,7 +130,7 @@ export const TypeEdit = defineComponent<Props>(props => {
                     id: 'select-etape-type',
                     placeholder: '',
                     items: [...getKeys(items, isEtapeTypeId)]
-                      .sort((a, _b) => (items[a]?.mainStep ?? false ? -1 : 1))
+                      .sort((a, _b) => ((items[a]?.mainStep ?? false) ? -1 : 1))
                       .map(etapeTypeId => EtapesTypes[etapeTypeId])
                       .filter(({ nom }) => {
                         return nom.toLowerCase().includes(etapeTypeSearch.value)


### PR DESCRIPTION
ils ont mis ça en place sur ma mission du vendredi, et je trouve ça plus lisible, et on peut ignorer les paramètres qu'on n'utilise pas